### PR TITLE
fix: stop using kqueue watch backend on macOS, canonicalize watch roots

### DIFF
--- a/crates/infigraph-core/src/watch/mod.rs
+++ b/crates/infigraph-core/src/watch/mod.rs
@@ -90,6 +90,13 @@ where
     MR: Fn() -> Result<crate::lang::LanguageRegistry> + Send + 'static,
     F: Fn(&crate::IndexResult) + Send + 'static,
 {
+    // Some watch backends (e.g. FSEvents on macOS) deliver absolute,
+    // symlink-resolved event paths regardless of how `root` was specified.
+    // If `root` is relative, or traverses a symlink (macOS temp dirs live
+    // under /var, itself a symlink to /private/var), `path.strip_prefix(root)`
+    // below silently fails for every event and all changes are dropped.
+    let root = &root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+
     let ignore_dirs: &[&str] = &[
         ".infigraph",
         ".git",
@@ -522,5 +529,85 @@ fn register_subdirs(watcher: &mut RecommendedWatcher, dir: &Path, ignore_dirs: &
         }
         let _ = watcher.watch(&path, RecursiveMode::NonRecursive);
         register_subdirs(watcher, &path, ignore_dirs);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Regression test for a macOS-specific bug: `watch_project_with_periodic`
+    /// used to compare raw filesystem-watch event paths against the caller's
+    /// `root` exactly as given. FSEvents delivers absolute, symlink-resolved
+    /// event paths, so a non-canonical `root` (e.g. a relative path, or one
+    /// that traverses a symlink) made `path.strip_prefix(root)` fail for
+    /// every event, silently dropping all changes with no error. This is the
+    /// same class of bug that made the `infigraph watch` CLI command — which
+    /// watched the unresolved `.` — appear to receive no events at all,
+    /// prompting a workaround (the kqueue backend) that caused a much larger
+    /// file-descriptor leak.
+    ///
+    /// A custom-prefixed `tempfile::TempDir` reproduces a non-canonical root
+    /// deterministically on macOS: it lives under `/var/folders/...`, itself
+    /// a symlink to `/private/var/folders/...`. (The default `TempDir::new()`
+    /// prefix starts with a dot, which the watcher's own hidden-file filter
+    /// would ignore regardless of this bug, so a custom prefix is used to
+    /// keep the test isolated to the canonicalization behavior.)
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn watch_project_detects_changes_through_symlinked_root() {
+        let tmp = tempfile::Builder::new()
+            .prefix("infigraph-watch-test-")
+            .tempdir()
+            .unwrap();
+        let raw_root = tmp.path().to_path_buf();
+        let canonical_root = raw_root.canonicalize().unwrap();
+        assert_ne!(
+            raw_root, canonical_root,
+            "test assumption broken: TempDir root is already canonical on this machine"
+        );
+
+        let file_path = raw_root.join("watched.txt");
+        std::fs::write(&file_path, "v1").unwrap();
+
+        let events: Arc<Mutex<Vec<WatchEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_clone = Arc::clone(&events);
+        let (stop_tx, stop_rx) = mpsc::channel();
+
+        let handle = std::thread::spawn(move || {
+            watch_project(
+                &raw_root,
+                || Ok(crate::lang::LanguageRegistry::new()),
+                50,
+                stop_rx,
+                move |evt| events_clone.lock().unwrap().push(evt),
+            )
+        });
+
+        // Give the watcher time to register before triggering a change.
+        std::thread::sleep(Duration::from_millis(300));
+        std::fs::remove_file(&file_path).unwrap();
+
+        // Poll rather than a single fixed sleep: fast on a quiet machine,
+        // robust on a loaded one.
+        let mut seen = false;
+        for _ in 0..40 {
+            std::thread::sleep(Duration::from_millis(100));
+            if !events.lock().unwrap().is_empty() {
+                seen = true;
+                break;
+            }
+        }
+
+        let _ = stop_tx.send(());
+        let _ = handle.join();
+
+        assert!(
+            seen,
+            "watch_project delivered no events for a change under a non-canonical \
+             (symlinked) root — the root.canonicalize() call in \
+             watch_project_with_periodic may have regressed"
+        );
     }
 }

--- a/crates/infigraph-docs/Cargo.toml
+++ b/crates/infigraph-docs/Cargo.toml
@@ -26,7 +26,7 @@ pdf_oxide = "0.3"
 calamine = "0.35"
 zip = "2"
 quick-xml = "0.37"
-notify = { version = "6", features = ["macos_kqueue"] }
+notify = "6"
 chrono = "0.4.45"
 fs2 = "0.4.3"
 


### PR DESCRIPTION
## Summary

Fixes #9. On macOS, `infigraph-mcp` workers leak file descriptors until `kern.maxfiles` is exhausted system-wide (observed: two workers holding 176k/183k FDs, ~97% of the OS file table).

Root cause, confirmed via `cargo tree -e features -i notify -p notify`: `infigraph-docs/Cargo.toml` enables notify's `macos_kqueue` feature for its own doc watcher. Cargo feature unification applies that feature workspace-wide to every crate depending on the same resolved `notify` version, so `infigraph-core`'s code watcher silently gets the kqueue backend too (its own `Cargo.toml` requests default features only — the opt-out is defeated). kqueue holds one open FD per watched file *and* per directory; a single watcher on a modest repo measurably held ~1,660 FDs, and on a real project tree that's tens of thousands, held open indefinitely.

This PR:
1. Removes `macos_kqueue` from `infigraph-docs/Cargo.toml`, switching macOS back to the default FSEvents backend (O(1) FDs regardless of tree size).
2. Canonicalizes `root` once at the top of `watch_project_with_periodic` (`infigraph-core/src/watch/mod.rs`). FSEvents delivers absolute, symlink-resolved event paths, so a non-canonical `root` (relative path, or one that traverses a symlink — macOS temp/build dirs commonly live under `/var`, itself a symlink to `/private/var`) made `path.strip_prefix(root)` fail silently for every event, dropping all changes with no error. This is almost certainly why kqueue was reached for in the first place — FSEvents looked broken when the actual bug was an uncanonicalized root. Fixing it in the core function (rather than at each call site) protects every caller — CLI `watch`, the MCP `watch_project` tool, and the doc watcher — at once.

## Test plan

- [x] `cargo test -p infigraph-core -p infigraph-docs` passes (single-threaded; parallel runs on this machine hit an unrelated Kuzu mmap resource-contention issue building N test DBs concurrently, not caused by this change — reproduces the same way on `main`)
- [x] `cargo clippy -p infigraph-core -p infigraph-docs --all-targets` passes with zero new warnings (one pre-existing `useless_borrows_in_formatting` lint in `vuln/mod.rs` reproduces identically on unpatched `main` with this toolchain — unrelated to this change, not touched here)
- [x] `cargo fmt --all -- --check` introduces zero new diffs (confirmed by diffing before/after this patch — pre-existing drift on ~76 unrelated files exists on `main` already with this local rustfmt version, not touched here)
- [x] Tested manually:
  - Added a regression test (`watch_project_detects_changes_through_symlinked_root`) that reproduces the symlink-root bug deterministically via a custom-prefixed `TempDir` and asserts a file-removal event is delivered. Verified it fails without the `canonicalize()` fix and passes with it.
  - Built both `infigraph` and `infigraph-mcp` release binaries with this patch and drove them directly over stdio (JSON-RPC) against a real 40-file test project: watcher FD count stayed at 8–9 for the life of the process (vs. 83 FDs, 73 pinned to the tree, on the unpatched kqueue build), and file modifications were correctly detected and triggered reindexing (`[watch] batch indexing 1 files`).
  - Found and killed a live, unpatched `infigraph watch` CLI process during this investigation holding **184,324 FDs** ~25 minutes after spawn; killing it dropped `kern.num_files` from 199,277 to 14,916 within seconds — confirming the FDs are genuinely held by the process (not a kernel accounting artifact) and are fully reclaimed on exit.

## Notes

- Full root-cause writeup, evidence, and repro steps are in #9.
- I considered fixing only the CLI's `cmd_watch` (which is the one call site that watches an unresolved `.`), but moving the canonicalize into `watch_project_with_periodic` itself is more robust — it can't be reintroduced by a future caller that forgets to canonicalize (the MCP tool's `tool_watch_project` already canonicalizes independently, so this is technically redundant for that path today, but removes the foot-gun for future call sites).
- Not addressed here (tracked as follow-ups in #9, since they're independent of the kqueue root cause): `--ui` workers never exiting after stdin EOF, `auto_start_watch_opportunistic` bypassing the `watchers_disabled` instance-lock guard, and the watcher-restart path leaking FDs from prior generations when the backend's internal thread dies. Happy to take these on in follow-up PRs if that's useful — wanted to keep this one scoped to the single root cause with a clean, verifiable diff.
