### PR TITLE
fix: prevent duplicate MCP watchers on the same project across processes

### DIFF
--- a/crates/infigraph-mcp/src/tools/watch.rs
+++ b/crates/infigraph-mcp/src/tools/watch.rs
@@ -83,10 +83,6 @@ fn auto_start_watch_inner(path: &str, skip_disabled_check: bool) -> Option<Strin
         return None;
     }
 
-    if cli_watcher_holds_lock(&root) {
-        return None;
-    }
-
     let args = serde_json::json!({
         "path": path,
         "auto_resolve": true,
@@ -104,25 +100,35 @@ fn auto_start_watch_inner(path: &str, skip_disabled_check: bool) -> Option<Strin
     }
 }
 
-fn cli_watcher_holds_lock(root: &std::path::Path) -> bool {
+/// Acquire the per-project watch lock (`.infigraph/watch.lock`), the same
+/// lock the CLI's `infigraph watch` holds for its lifetime. Retries briefly:
+/// a watcher that was just told to stop may take up to its poll interval
+/// (~200ms) to actually exit and release this lock, and without a retry
+/// window a start attempt landing in that gap would spuriously fail.
+fn acquire_project_watch_lock(lock_path: &std::path::Path) -> Result<std::fs::File> {
     use fs2::FileExt;
-    let lock_path = root.join(".infigraph").join("watch.lock");
-    let file = match std::fs::OpenOptions::new()
-        .create(false)
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let file = std::fs::OpenOptions::new()
+        .create(true)
         .write(true)
         .truncate(false)
-        .open(&lock_path)
-    {
-        Ok(f) => f,
-        Err(_) => return false,
-    };
-    match file.try_lock_exclusive() {
-        Ok(()) => {
-            let _ = file.unlock();
-            false
+        .open(lock_path)?;
+
+    const ATTEMPTS: u32 = 10;
+    const RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(50);
+    let mut last_err = None;
+    for _ in 0..ATTEMPTS {
+        match file.try_lock_exclusive() {
+            Ok(()) => return Ok(file),
+            Err(e) => {
+                last_err = Some(e);
+                std::thread::sleep(RETRY_DELAY);
+            }
         }
-        Err(_) => true,
     }
+    Err(last_err.unwrap().into())
 }
 
 pub fn tool_watch_project(args: &Value) -> Result<String> {
@@ -145,6 +151,15 @@ pub fn tool_watch_project(args: &Value) -> Result<String> {
         .canonicalize()
         .context("invalid path")?;
     let root_str = root.to_string_lossy().replace('\\', "/");
+
+    let lock_path = root.join(".infigraph").join("watch.lock");
+    let watch_lock = acquire_project_watch_lock(&lock_path).map_err(|_| {
+        anyhow::anyhow!(
+            "another watcher is already running for {root_str} \
+             (CLI `infigraph watch` or another MCP worker) — \
+             use get_watch_status to check, or stop it first"
+        )
+    })?;
 
     let (stop_tx, stop_rx) = mpsc::channel::<()>();
     let watcher_id = format!(
@@ -174,6 +189,8 @@ pub fn tool_watch_project(args: &Value) -> Result<String> {
 
     let watcher_id_clone = watcher_id.clone();
     std::thread::spawn(move || {
+        // Held for the watcher's lifetime; released when this thread exits.
+        let _watch_lock = watch_lock;
         let id_short = watcher_id_clone[..12.min(watcher_id_clone.len())].to_string();
         if auto_resolve {
             if let Err(e) = infigraph_core::watch::watch_project_auto_resolve(

--- a/crates/infigraph-mcp/tests/watcher_concurrency.rs
+++ b/crates/infigraph-mcp/tests/watcher_concurrency.rs
@@ -34,14 +34,19 @@ fn make_project(files: &[(&str, &str)]) -> (tempfile::TempDir, String) {
 
 fn stop_all_watchers() {
     let mut guard = get_watchers();
-    if let Some(map) = guard.as_mut() {
+    let stopped_paths: Vec<String> = if let Some(map) = guard.as_mut() {
         let ids: Vec<String> = map.keys().cloned().collect();
+        let mut paths = Vec::new();
         for id in ids {
             if let Some(entry) = map.remove(&id) {
+                paths.push(entry.path.clone());
                 let _ = entry.stop_tx.send(());
             }
         }
-    }
+        paths
+    } else {
+        Vec::new()
+    };
     drop(guard);
     let mut doc_guard = get_doc_watchers();
     if let Some(map) = doc_guard.as_mut() {
@@ -49,6 +54,46 @@ fn stop_all_watchers() {
         for id in ids {
             if let Some(entry) = map.remove(&id) {
                 let _ = entry.stop_tx.send(());
+            }
+        }
+    }
+    drop(doc_guard);
+    wait_for_watch_locks_released(&stopped_paths);
+}
+
+/// A stopped watcher's thread notices `stop_rx` on its own poll cadence and
+/// may still be mid-reindex, so it doesn't release `.infigraph/watch.lock`
+/// the instant the stop signal is sent. Block (with a generous bound) until
+/// each path's lock is confirmed free, so tests that immediately re-watch
+/// the same project aren't racing the previous watcher's shutdown.
+fn wait_for_watch_locks_released(paths: &[String]) {
+    use fs2::FileExt;
+    for path in paths {
+        let lock_path = std::path::Path::new(path)
+            .join(".infigraph")
+            .join("watch.lock");
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let file = match std::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(false)
+                .open(&lock_path)
+            {
+                Ok(f) => f,
+                Err(_) => break,
+            };
+            match file.try_lock_exclusive() {
+                Ok(()) => {
+                    let _ = file.unlock();
+                    break;
+                }
+                Err(_) => {
+                    if std::time::Instant::now() >= deadline {
+                        break;
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(20));
+                }
             }
         }
     }
@@ -402,6 +447,40 @@ fn test_mcp_starts_when_no_cli_lock() {
     assert!(
         result.is_some(),
         "should start when no CLI lock, got None for path: {path}"
+    );
+}
+
+/// Regression test: two `tool_watch_project` calls for the same path — as
+/// two different MCP worker processes would each make independently, with
+/// no shared in-process state — must not both succeed. Before this fix,
+/// `tool_watch_project` never acquired `.infigraph/watch.lock` itself (only
+/// `auto_start_watch`'s `cli_watcher_holds_lock` pre-check read it, and only
+/// to detect a CLI-held lock), so nothing gated a second MCP-started watcher
+/// on the same project — every worker built its own duplicate watcher set.
+/// Calling `tool_watch_project` directly here (bypassing `auto_start_watch`'s
+/// own in-process `is_watching` map, which would otherwise mask this) proves
+/// the dedup now comes from the lock itself, not from in-process state that
+/// a second worker process wouldn't share.
+#[test]
+fn test_second_watch_project_call_declines_when_already_watching() {
+    let _guard = WATCHER_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _cleanup = WatcherCleanup;
+    stop_all_watchers();
+    init_watchers();
+    let (_dir, path) = make_project(&[("main.py", "def hello(): pass")]);
+
+    let first = tool_watch_project(&json!({"path": &path}));
+    assert!(first.is_ok(), "first watcher should start: {first:?}");
+
+    let second = tool_watch_project(&json!({"path": &path}));
+    assert!(
+        second.is_err(),
+        "a second watch_project call for an already-watched path must decline, not start a duplicate watcher"
+    );
+    let err = second.unwrap_err().to_string();
+    assert!(
+        err.contains("already running"),
+        "expected an 'already running' decline message, got: {err}"
     );
 }
 

--- a/crates/infigraph-mcp/tests/watcher_reindex.rs
+++ b/crates/infigraph-mcp/tests/watcher_reindex.rs
@@ -38,11 +38,56 @@ fn make_project(files: &[(&str, &str)]) -> (tempfile::TempDir, String) {
 
 fn stop_all_watchers() {
     let mut guard = get_watchers();
-    if let Some(map) = guard.as_mut() {
+    let stopped_paths: Vec<String> = if let Some(map) = guard.as_mut() {
         let ids: Vec<String> = map.keys().cloned().collect();
+        let mut paths = Vec::new();
         for id in ids {
             if let Some(entry) = map.remove(&id) {
+                paths.push(entry.path.clone());
                 let _ = entry.stop_tx.send(());
+            }
+        }
+        paths
+    } else {
+        Vec::new()
+    };
+    drop(guard);
+    wait_for_watch_locks_released(&stopped_paths);
+}
+
+/// A stopped watcher's thread notices `stop_rx` on its own poll cadence and
+/// may still be mid-reindex, so it doesn't release `.infigraph/watch.lock`
+/// the instant the stop signal is sent. Block (with a generous bound) until
+/// each path's lock is confirmed free, so tests that immediately re-watch
+/// the same project aren't racing the previous watcher's shutdown.
+fn wait_for_watch_locks_released(paths: &[String]) {
+    use fs2::FileExt;
+    for path in paths {
+        let lock_path = std::path::Path::new(path)
+            .join(".infigraph")
+            .join("watch.lock");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let file = match std::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(false)
+                .open(&lock_path)
+            {
+                Ok(f) => f,
+                Err(_) => break,
+            };
+            match file.try_lock_exclusive() {
+                Ok(()) => {
+                    let _ = file.unlock();
+                    break;
+                }
+                Err(_) => {
+                    if Instant::now() >= deadline {
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_millis(20));
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Follow-up from the investigation in #9/#10 (macOS FD leak) and #11/#12 (scip-enrich arg fix) — a related but independent bug in MCP watcher lifecycle, not fixed by either of those.

`tool_watch_project` never acquired `.infigraph/watch.lock` itself. The only existing guard, `cli_watcher_holds_lock` (used solely by `auto_start_watch`'s pre-check), just *peeked* at whether a CLI-started watcher held the lock — it never gated one MCP worker's watcher against another MCP worker's, since neither ever took the lock. Every worker process that called `index_project`, `group_index`, or `search` therefore built its own duplicate watcher set for the same project — each independently walking the tree and reindexing on every file change.

This PR makes `tool_watch_project` acquire that same per-project lock itself before spawning its watcher thread, and hold it for the watcher's lifetime — mirroring exactly what the CLI's own `cmd_watch`/`ensure_watcher_running` already do via `acquire_watch_lock` (`info_commands.rs:412-425`). A second attempt to watch an already-watched project (from another MCP worker, or another explicit `watch_project` call) now fails with an "already running" error, which flows into `auto_start_watch`'s existing `Err(e) => None` branch — so the documented "returns `None` when another watcher already covers this project" contract is unchanged for existing callers/tests, just now correctly enforced against MCP-vs-MCP duplication too, not only MCP-vs-CLI.

Went with graceful decline (fail to acquire → don't start a duplicate) rather than kill-and-take-over: `try_lock_exclusive` is an OS-level advisory flock, which the kernel releases automatically the instant a holding process dies — there's no "stale lock from a dead process" scenario to justify forcibly breaking a live holder's lock, and doing so would risk killing a watcher that's still doing real work for a different, legitimate client.

Acquisition retries briefly (up to ~500ms) since a watcher that was just told to stop may take up to its ~200ms poll interval to actually exit and release the lock; without this, a legitimate restart attempt landing in that handover window would spuriously fail.

### Test infra fix included

While verifying this, found a latent race in the test suite itself: `stop_all_watchers()` (duplicated in `watcher_concurrency.rs` and `watcher_reindex.rs`) only *signals* watcher threads to stop, without waiting for them to actually exit. Once `tool_watch_project` started holding a real lock, this raced legitimately — a test that stopped a watcher and immediately re-watched the same path could hit the handover window and get a false "already running" failure (reproduced this exact failure with `test_mcp_starts_when_no_cli_lock` before fixing it). Both copies of the helper now wait, with a bounded timeout, for the stopped watcher's lock to be confirmed released before returning.

## Test plan

- [x] `cargo test -p infigraph-mcp --test watcher_concurrency --test watcher_reindex` passes (25 tests, single-threaded)
- [x] `cargo clippy -p infigraph-mcp --all-targets -- -D warnings` passes with zero new warnings (allowing only the two pre-existing lints confirmed to reproduce identically on unpatched `main`, in files untouched by this change)
- [x] `cargo fmt --all -- --check` introduces zero new diffs vs. `main`
- [x] Tested manually:
  - Added `test_second_watch_project_call_declines_when_already_watching`, which calls `tool_watch_project` twice directly for the same path — bypassing `auto_start_watch`'s own in-process `is_watching` map, so the test proves the *lock* itself (not in-process state a second real worker process wouldn't share) is what prevents the duplicate. Confirmed it fails when the lock acquisition is temporarily bypassed and passes with the fix.
  - Confirmed the pre-existing `test_mcp_skips_when_cli_lock_held` / `test_mcp_starts_when_no_cli_lock` / `test_no_stale_warning_with_cli_watcher` tests all pass unchanged — the `None`-on-decline contract for the CLI-lock case is preserved exactly.

## Notes

- Independent of #10/#12 — different files, no overlap, can merge in any order.
- `cli_watcher_holds_lock` is removed (dead code once its only call site — the now-redundant pre-check in `auto_start_watch_inner` — is gone; `tool_watch_project`'s own acquire-attempt subsumes it for both CLI-held and MCP-held locks).
