### PR TITLE
fix: don't attempt Postgres connection for local Kùzu indexing

### DIFF
--- a/crates/infigraph-cli/src/index.rs
+++ b/crates/infigraph-cli/src/index.rs
@@ -135,10 +135,7 @@ pub(crate) fn cmd_index(root: &Path, full: bool, no_embed: bool) -> Result<()> {
     // In remote mode, register this repo in Postgres so it appears in registry queries
     #[cfg(feature = "remote")]
     {
-        if std::env::var("INFIGRAPH_BACKEND")
-            .map(|v| v == "neo4j")
-            .unwrap_or(false)
-        {
+        if is_neo4j_backend() {
             let canonical = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
             let repo_name = canonical
                 .file_name()
@@ -178,7 +175,8 @@ pub(crate) fn cmd_index(root: &Path, full: bool, no_embed: bool) -> Result<()> {
         let mut done = false;
 
         #[cfg(feature = "remote")]
-        if let Some(backend) = prism.backend() {
+        if is_neo4j_backend() {
+            let backend = prism.backend().context("graph not initialized")?;
             let pg = infigraph_core::meta::PostgresMetaStore::connect_from_env()?;
             pg.init_schema()?;
             let count = infigraph_core::embed::update_embeddings_remote(backend, &pg, &changed)?;
@@ -285,6 +283,24 @@ fn spawn_scip_child_process(root: &Path, detected_languages: &std::collections::
 /// without spawning a process.
 fn scip_enrich_args(langs: &str) -> Vec<String> {
     vec!["scip-enrich".to_string(), langs.to_string()]
+}
+
+/// Whether the active backend is remote Neo4j (vs. the default local Kùzu).
+///
+/// `Infigraph::backend()` used to return `None` for the default Kùzu
+/// backend, so `if let Some(backend) = prism.backend()` doubled as a de
+/// facto "are we in remote mode" check. Once `backend()` was made universal
+/// (returning `Some` for every backend kind, including local Kùzu), that
+/// check silently broke: the Postgres-embeddings branch below started
+/// firing on every `remote`-feature build regardless of backend, attempting
+/// a Postgres connection even for plain local indexing and failing the
+/// whole `index` command with a connection-refused error. Extracted so the
+/// exact condition can be unit-tested independently of a real backend.
+#[cfg(feature = "remote")]
+fn is_neo4j_backend() -> bool {
+    std::env::var("INFIGRAPH_BACKEND")
+        .map(|v| v == "neo4j")
+        .unwrap_or(false)
 }
 
 /// Decides what (if anything) to warn about after waiting on the detached
@@ -997,6 +1013,40 @@ mod tests {
                 .is_some_and(|m| m.contains("failed to wait on scip-enrich")),
             "expected a warning about the wait() failure, got {msg:?}"
         );
+    }
+
+    /// Regression test for the Postgres-connect-on-plain-local-index bug:
+    /// `Infigraph::backend()` became universal (returning `Some` for the
+    /// default local Kùzu backend too, not just Neo4j), which silently
+    /// turned `if let Some(backend) = prism.backend()` into an always-true
+    /// check gating the Postgres-embeddings branch — so `infigraph index`
+    /// tried to connect to Postgres and failed even for plain local
+    /// indexing with no remote backend configured. `is_neo4j_backend()`
+    /// replaces that check with the same explicit `INFIGRAPH_BACKEND`
+    /// check already used a few lines above it (repo registration) —
+    /// asserts it's only true for an explicit `neo4j` value.
+    #[test]
+    #[cfg(feature = "remote")]
+    fn is_neo4j_backend_only_true_for_explicit_neo4j_env() {
+        std::env::remove_var("INFIGRAPH_BACKEND");
+        assert!(
+            !is_neo4j_backend(),
+            "unset INFIGRAPH_BACKEND must not select Postgres"
+        );
+
+        std::env::set_var("INFIGRAPH_BACKEND", "kuzu");
+        assert!(
+            !is_neo4j_backend(),
+            "explicit kuzu backend must not select Postgres"
+        );
+
+        std::env::set_var("INFIGRAPH_BACKEND", "neo4j");
+        assert!(
+            is_neo4j_backend(),
+            "explicit neo4j backend must select Postgres"
+        );
+
+        std::env::remove_var("INFIGRAPH_BACKEND");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`Infigraph::backend()` was made universal in the recent GraphBackend-trait
refactor (returning `Some` for the default local Kùzu backend too, not just
Neo4j). That silently broke the `if let Some(backend) = prism.backend()`
check in `index.rs`'s embeddings step, which previously relied on
`backend()`'s `None`/`Some` split as a de facto "are we in remote mode"
check. Once `backend()` became universal, that check became always-true
under any `remote`-feature build — so plain local indexing with no
`INFIGRAPH_BACKEND` configured tries to connect to Postgres and fails the
whole `index` command with a connection-refused error, even though the
graph itself already indexed successfully.

Repro (with `--features remote` built, `INFIGRAPH_BACKEND` unset):
```
$ infigraph index --full
...
Graph Statistics: ...   <- indexing succeeded
Error: postgres connect failed: Error { kind: Connect, cause: Some(Os { code: 61, kind: ConnectionRefused, ... }) }
```

## Fix

Extract `is_neo4j_backend()`, which checks `INFIGRAPH_BACKEND == "neo4j"`
explicitly — the same pattern already used correctly a few lines above in
the same function for repo registration (`index.rs`'s "In remote mode,
register this repo in Postgres..." block). Use it at both call sites
instead of relying on `backend()`'s `Some`-ness.

## Test plan

- [x] `cargo build -p infigraph-cli --features remote` — compiles clean
- [x] `cargo build -p infigraph-cli` (default, no `remote` feature) — compiles clean, `is_neo4j_backend` properly `cfg`-gated
- [x] `cargo test -p infigraph-cli --features remote` — new regression test `is_neo4j_backend_only_true_for_explicit_neo4j_env` passes
- [x] End-to-end: built with `--features remote`, ran `index --full` against a clean project with `INFIGRAPH_BACKEND` unset — previously failed with connection-refused, now completes and saves to `.infigraph/embeddings.bin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAXDJyFdnA4BV1U2fxufdC