### PR TITLE
fix: don't wipe the graph on lock contention from another live process

### DIFF
--- a/crates/infigraph-core/src/lib.rs
+++ b/crates/infigraph-core/src/lib.rs
@@ -55,6 +55,18 @@ pub(crate) fn escape_str(s: &str) -> String {
 pub fn build_hash() -> &'static str {
     env!("INFIGRAPH_BUILD_HASH")
 }
+
+/// Kuzu's IO-layer error for "another process holds this database's lock"
+/// (see docs.ladybugdb.com/concurrency) is lock contention, not corruption.
+/// `GraphStore::open` collapses the underlying Kuzu error into a stringified
+/// `anyhow::Error` before it reaches `Infigraph::init`, so there's no
+/// structured error variant to match on here -- only Kuzu's own error text.
+/// This was previously indistinguishable from genuine corruption, so a
+/// second `infigraph` process opening a graph while a watcher already had
+/// it open would trigger `wipe_graph`, destroying the watcher's live data.
+fn is_lock_contention_error(err: &anyhow::Error) -> bool {
+    err.to_string().contains("Could not set lock on file")
+}
 /// The main entry point for the infigraph framework.
 pub struct Infigraph {
     root: PathBuf,
@@ -116,6 +128,16 @@ impl Infigraph {
                 Ok(kb) => {
                     self.backend_kind = BackendKind::Kuzu(kb);
                     Ok(())
+                }
+                Err(first_err) if is_lock_contention_error(&first_err) => {
+                    // Another live process (e.g. a running `infigraph watch`) holds
+                    // this database open -- not corruption. Wiping here would destroy
+                    // a perfectly good graph out from under that process.
+                    Err(first_err).with_context(|| {
+                        "graph is locked by another infigraph process (e.g. a running \
+                         `infigraph watch`) -- not corrupted, so it was left untouched. \
+                         Run `infigraph watch-status` or try again in a moment."
+                    })
                 }
                 Err(first_err) => {
                     eprintln!(
@@ -523,4 +545,41 @@ pub struct IndexResult {
     pub indexed_files: usize,
     pub extractions: Vec<FileExtraction>,
     pub resolve_stats: resolve::ResolveStats,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test for a data-loss bug: `Infigraph::init()` used to
+    /// treat every Kuzu open failure as corruption and wipe the graph --
+    /// including plain lock contention from another live process (e.g. a
+    /// running `infigraph watch`), destroying its data. `is_lock_contention_error`
+    /// is the check that now distinguishes the two. A genuine two-OS-process
+    /// reproduction isn't exercised here -- `Database::new()` doesn't
+    /// conflict across two `Infigraph` instances in the *same* process, only
+    /// across separate processes, and this codebase deliberately avoids
+    /// fork()-based tests given the tokio/rayon runtime state that would be
+    /// undefined in a forked child (same reasoning as `scip_enrich_exit_message`
+    /// in infigraph-cli's index.rs, which tests extracted logic rather than
+    /// the full spawn path for the same class of reason).
+    #[test]
+    fn is_lock_contention_error_matches_kuzu_lock_message() {
+        let err = anyhow::anyhow!(
+            "failed to open kuzu db: IO exception: Could not set lock on file : /repo/.infigraph/graph"
+        );
+        assert!(is_lock_contention_error(&err));
+    }
+
+    #[test]
+    fn is_lock_contention_error_does_not_match_genuine_corruption() {
+        let err = anyhow::anyhow!(
+            "failed to open kuzu db: Runtime exception: Database ID for temporary file \
+             '/repo/.infigraph/graph.wal.checkpoint' does not match the current database."
+        );
+        assert!(
+            !is_lock_contention_error(&err),
+            "a genuine format/ID mismatch must still be treated as corruption and wiped"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`Infigraph::init()` treats every `KuzuBackend::open()` failure as
corruption and wipes + rebuilds the database -- including Kuzu's own
`"Could not set lock on file"` error, which is plain lock contention from
another live process (e.g. a running `infigraph watch` that already has
the database open), not corruption at all.

Concretely: run `infigraph watch` in one terminal, then run any other
`infigraph` command (`stats`, `index`, ...) against the same project in
another terminal while the watcher is alive. The second command's open
attempt fails with a lock error, `init()` treats that as corruption, wipes
`.infigraph/graph`, and rebuilds from whatever partial state is visible at
that moment -- destroying the watcher's live data out from under it. This
happened twice in a row against a real project in my own use.

## Fix

Add `is_lock_contention_error()`, which checks for Kuzu's lock-contention
error text specifically (`GraphStore::open` collapses the underlying Kuzu
error into a stringified `anyhow::Error` before it reaches `Infigraph::init`,
so there's no structured error variant to match on -- only Kuzu's own error
text). On lock contention, return a clear
`"graph is locked by another infigraph process ... not corrupted, so it was
left untouched"` error instead of wiping. Genuine corruption (e.g. the
`"Database ID ... does not match"` error from a stale/mismatched WAL
checkpoint file) still triggers the existing wipe-and-rebuild recovery --
only lock contention is exempted.

## Test plan

- [x] Unit tests: `is_lock_contention_error_matches_kuzu_lock_message`,
      `is_lock_contention_error_does_not_match_genuine_corruption`
- [x] Full `infigraph-core` unit test suite (268 tests) passes, no regressions
- [x] End-to-end with two real, separate OS processes: started a real
      `infigraph watch` holding a graph open, ran `infigraph stats` against
      the same project in a second process. Before this fix: the second
      call's failure wiped the watcher's graph. After: it returns the clear
      error above and the watcher's data survives intact (confirmed via
      `stats` on the still-running watcher after the second call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAXDJyFdnA4BV1U2fxufdC