### PR TITLE
fix(remote): correct webhook reindex + shared-Neo4j namespacing (v3.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [3.2.3] - 2026-07-21
+
+### Fixed
+
+- Remote (shared-Neo4j) mode: a single-repo webhook no longer re-indexes every
+  repo in the group, and combined-graph queries no longer return 0 while
+  per-repo queries succeed. Root cause was read/write disagreement on repo
+  identity plus a Kùzu-only transaction statement leaking into Neo4j:
+  - Webhook now pulls and runs `group build` only — the standalone `index`
+    step (wrong namespace + stole the commit-change signal) is removed.
+  - `f.repo` is stamped as `org/repo` at write time in both the per-file and
+    bulk write paths; the global unfiltered `f.repo` backfill in `upsert_repo`
+    (which stole orphan files across repos) is removed.
+  - Group indexing scopes reads to the repo being indexed, so reindexing one
+    repo no longer deletes every other repo's data from the shared graph.
+  - Read filters resolve the same `org/repo` key that writes use.
+  - `BEGIN TRANSACTION`/`COMMIT`/`ROLLBACK` are no-ops on the Neo4j backend
+    (valid Kùzu, invalid Cypher), fixing concern/taint/reflection/config/
+    dynamic-URL analysis in remote mode.
+  - Org-scoped groups are usable from the CLI: `group add`/`build`/`index`
+    resolve a bare group name to its org-qualified key.
+- Remote mode `index` now resolves a repo's `org/repo` namespace from the group
+  registry and refuses to index a repo that isn't registered in any group,
+  instead of inventing a namespace from the directory name.
+
 ## [0.10.1] - 2026-05-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "infigraph-cli"
-version = "3.2.1"
+version = "3.2.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2445,7 +2445,7 @@ dependencies = [
 
 [[package]]
 name = "infigraph-confluence"
-version = "3.2.1"
+version = "3.2.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "infigraph-core"
-version = "3.2.1"
+version = "3.2.3"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2497,7 +2497,7 @@ dependencies = [
 
 [[package]]
 name = "infigraph-docs"
-version = "3.2.1"
+version = "3.2.3"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2523,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "infigraph-grammar-plugin"
-version = "3.2.1"
+version = "3.2.3"
 dependencies = [
  "anyhow",
  "dirs-next",
@@ -2536,7 +2536,7 @@ dependencies = [
 
 [[package]]
 name = "infigraph-languages"
-version = "3.2.1"
+version = "3.2.3"
 dependencies = [
  "anyhow",
  "infigraph-core",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "infigraph-mcp"
-version = "3.2.1"
+version = "3.2.3"
 dependencies = [
  "anyhow",
  "fs2",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "infigraph-pipeline-plugin"
-version = "3.2.1"
+version = "3.2.3"
 dependencies = [
  "anyhow",
  "dirs-next",
@@ -3006,7 +3006,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lsp-to-scip"
-version = "3.2.1"
+version = "3.2.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "3.2.2"
+version = "3.2.3"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/intuit/infigraph"

--- a/crates/infigraph-cli/src/group_commands.rs
+++ b/crates/infigraph-cli/src/group_commands.rs
@@ -20,6 +20,7 @@ pub(crate) fn cmd_group(root: &Path, action: GroupAction) -> Result<()> {
             println!("Created group '{}'", key);
         }
         GroupAction::Add { group, repo } => {
+            let group = registry.resolve_group_key(&group);
             let repo_path = std::path::Path::new(&repo);
             let (repo_name, actual_path) = if repo_path.is_dir() {
                 let name = repo_path
@@ -47,6 +48,7 @@ pub(crate) fn cmd_group(root: &Path, action: GroupAction) -> Result<()> {
             );
         }
         GroupAction::Remove { group, repo } => {
+            let group = registry.resolve_group_key(&group);
             registry.group_remove(&group, &repo)?;
             registry.save()?;
             println!("Removed repo '{}' from group '{}'", repo, group);
@@ -64,6 +66,7 @@ pub(crate) fn cmd_group(root: &Path, action: GroupAction) -> Result<()> {
             }
         }
         GroupAction::Index { group, full } => {
+            let group = registry.resolve_group_key(&group);
             let g = registry
                 .groups
                 .get(&group)
@@ -168,6 +171,7 @@ pub(crate) fn cmd_group(root: &Path, action: GroupAction) -> Result<()> {
             );
         }
         GroupAction::Combined { group } => {
+            let group = registry.resolve_group_key(&group);
             let g = registry
                 .groups
                 .get(&group)
@@ -189,6 +193,7 @@ pub(crate) fn cmd_group(root: &Path, action: GroupAction) -> Result<()> {
             );
         }
         GroupAction::CombinedDocs { group } => {
+            let group = registry.resolve_group_key(&group);
             let stats = infigraph_docs::combined::build_combined_docs(&registry, &group)?;
             println!(
                 "Combined document store ready: {} documents, {} chunks, {} links ({} intra-repo, {} cross-repo), {} sources, {} embeddings.",
@@ -202,6 +207,7 @@ pub(crate) fn cmd_group(root: &Path, action: GroupAction) -> Result<()> {
             );
         }
         GroupAction::Sync { group } => {
+            let group = registry.resolve_group_key(&group);
             let count = infigraph_core::multi::sync_group_contracts(
                 &mut registry,
                 &group,
@@ -210,6 +216,7 @@ pub(crate) fn cmd_group(root: &Path, action: GroupAction) -> Result<()> {
             println!("Synced {} contracts in group '{}'", count, group);
         }
         GroupAction::Contracts { group } => {
+            let group = registry.resolve_group_key(&group);
             let g = registry
                 .groups
                 .get(&group)
@@ -230,6 +237,7 @@ pub(crate) fn cmd_group(root: &Path, action: GroupAction) -> Result<()> {
             }
         }
         GroupAction::Deps { group } => {
+            let group = registry.resolve_group_key(&group);
             let deps = infigraph_core::multi::detect_cross_service_deps(
                 &registry,
                 &group,
@@ -257,6 +265,7 @@ pub(crate) fn cmd_group(root: &Path, action: GroupAction) -> Result<()> {
             }
         }
         GroupAction::Link { group } => {
+            let group = registry.resolve_group_key(&group);
             let count = infigraph_core::multi::link_cross_service_calls(
                 &registry,
                 &group,
@@ -272,6 +281,7 @@ pub(crate) fn cmd_group(root: &Path, action: GroupAction) -> Result<()> {
             cypher,
             combined,
         } => {
+            let group = registry.resolve_group_key(&group);
             if combined {
                 let rows = infigraph_core::multi::combined::combined_query(&group, &cypher)?;
                 for row in &rows {
@@ -288,6 +298,7 @@ pub(crate) fn cmd_group(root: &Path, action: GroupAction) -> Result<()> {
             }
         }
         GroupAction::Build { group, full } => {
+            let group = registry.resolve_group_key(&group);
             // Step 1: Index (uses index_group for namespace isolation + parallel on Neo4j)
             let results =
                 infigraph_core::multi::index_group(&mut registry, &group, full, bundled_registry)?;
@@ -411,6 +422,7 @@ pub(crate) fn cmd_group(root: &Path, action: GroupAction) -> Result<()> {
             alpha,
             deep,
         } => {
+            let group = registry.resolve_group_key(&group);
             if deep {
                 let output = infigraph_core::multi::combined::combined_search_deep(
                     &group, &query, limit, alpha,
@@ -448,6 +460,7 @@ pub(crate) fn cmd_group(root: &Path, action: GroupAction) -> Result<()> {
             limit,
             alpha,
         } => {
+            let group = registry.resolve_group_key(&group);
             let results =
                 infigraph_docs::combined::combined_doc_search(&group, &query, limit, alpha)?;
             if results.is_empty() {
@@ -466,6 +479,7 @@ pub(crate) fn cmd_group(root: &Path, action: GroupAction) -> Result<()> {
             }
         }
         GroupAction::Watch { group, debounce } => {
+            let group = registry.resolve_group_key(&group);
             let g = registry
                 .groups
                 .get(&group)

--- a/crates/infigraph-cli/src/index.rs
+++ b/crates/infigraph-cli/src/index.rs
@@ -46,15 +46,31 @@ pub(crate) fn cmd_index(root: &Path, full: bool, no_embed: bool) -> Result<()> {
     let mut prism = Infigraph::open(root, registry)?;
     prism.init()?;
 
-    // In shared Neo4j mode, namespace-prefix all file/symbol IDs to prevent collisions
-    if remote {
-        let canonical = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
-        let repo_name = canonical
-            .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_else(|| "unknown".to_string());
-        prism.set_namespace(&repo_name);
-    }
+    // In shared Neo4j mode, a repo's identity is defined by the group registry, not by its
+    // directory name. Resolve the `org/repo` namespace from the registry so a standalone
+    // `infigraph index` writes data consistent with `group build` and the read filters.
+    // Refuse to index an unregistered repo: writing a locally-invented namespace into the
+    // shared graph produces orphaned, mis-namespaced nodes (the original reindter bug).
+    #[cfg(feature = "remote")]
+    let remote_ns = if remote {
+        let reg = infigraph_core::multi::Registry::load()?;
+        let ns = reg.resolve_repo_namespace(root).ok_or_else(|| {
+            anyhow::anyhow!(
+                "repo at '{}' is not registered in any group; in remote mode run \
+                 `infigraph group add <group> <path>` first so its org/repo namespace is defined. \
+                 (A standalone index cannot invent a namespace for a shared graph.)",
+                root.display()
+            )
+        })?;
+        prism.set_namespace(&ns);
+        // Scope reads (get_file_hashes / stale-prune) to THIS repo. Without this, a
+        // standalone index fetches every repo's file hashes from the shared graph and the
+        // stale-file prune deletes all OTHER repos' data — same hazard as group indexing.
+        prism.set_repo_filter(&ns);
+        Some(ns)
+    } else {
+        None
+    };
 
     println!("Indexing project...");
     let result = prism.index()?;
@@ -193,10 +209,12 @@ pub(crate) fn cmd_index(root: &Path, full: bool, no_embed: bool) -> Result<()> {
             registry.register_repo(&repo_name, root, &prism)?;
             println!("Registered '{}' in Postgres registry", repo_name);
 
-            // Create Repo node in Neo4j and link all files
+            // Create Repo node in Neo4j keyed by the org/repo namespace (matching f.repo),
+            // and link only this repo's files.
             if let Some(backend) = prism.backend() {
-                backend.upsert_repo(&repo_name)?;
-                println!("Created Repo node '{}' with BELONGS_TO edges", repo_name);
+                let repo_key = remote_ns.as_deref().unwrap_or(&repo_name);
+                backend.upsert_repo(repo_key)?;
+                println!("Created Repo node '{}' with BELONGS_TO edges", repo_key);
             }
         }
     }

--- a/crates/infigraph-core/src/graph/neo4j_backend.rs
+++ b/crates/infigraph-core/src/graph/neo4j_backend.rs
@@ -47,6 +47,9 @@ pub struct Neo4jBackend {
     graph: Graph,
     handle: Handle,
     repo_filter: Option<String>,
+    /// Namespace (`org/repo`) to stamp onto File nodes as `f.repo` at write time,
+    /// so repo-scoped read queries work without a global backfill. Set via `set_write_namespace`.
+    write_namespace: Option<String>,
 }
 
 impl Neo4jBackend {
@@ -58,6 +61,7 @@ impl Neo4jBackend {
             graph,
             handle,
             repo_filter: None,
+            write_namespace: None,
         })
     }
 
@@ -73,6 +77,11 @@ impl Neo4jBackend {
 
     pub fn set_repo_filter(&mut self, repo: &str) {
         self.repo_filter = Some(repo.to_string());
+    }
+
+    /// Set the namespace (`org/repo`) stamped onto File nodes as `f.repo` at write time.
+    pub fn set_write_namespace(&mut self, ns: &str) {
+        self.write_namespace = Some(ns.to_string());
     }
 
     /// Initialize schema constraints (idempotent).
@@ -177,15 +186,28 @@ impl Neo4jBackend {
     }
 
     fn upsert_extraction(&self, ext: &FileExtraction) -> Result<()> {
-        // File node
-        self.block_on(
-            self.graph.run(
-                query("MERGE (f:File {id: $id}) SET f.language = $lang")
-                    .param("id", ext.file.clone())
-                    .param("lang", ext.language.clone()),
-            ),
-        )
-        .map_err(|e| anyhow::anyhow!("upsert file failed: {e}"))?;
+        // File node — stamp f.repo from the write namespace so repo-scoped read queries
+        // (stats, get_file_hashes, get_all_symbols, ...) work without a global backfill.
+        if let Some(ns) = &self.write_namespace {
+            self.block_on(
+                self.graph.run(
+                    query("MERGE (f:File {id: $id}) SET f.language = $lang, f.repo = $repo")
+                        .param("id", ext.file.clone())
+                        .param("lang", ext.language.clone())
+                        .param("repo", ns.clone()),
+                ),
+            )
+            .map_err(|e| anyhow::anyhow!("upsert file failed: {e}"))?;
+        } else {
+            self.block_on(
+                self.graph.run(
+                    query("MERGE (f:File {id: $id}) SET f.language = $lang")
+                        .param("id", ext.file.clone())
+                        .param("lang", ext.language.clone()),
+                ),
+            )
+            .map_err(|e| anyhow::anyhow!("upsert file failed: {e}"))?;
+        }
 
         // Module node
         self.block_on(
@@ -966,6 +988,18 @@ impl GraphBackend for Neo4jBackend {
     }
 
     fn raw_query(&self, cypher: &str) -> Result<Vec<Vec<String>>> {
+        // Kuzu accepts `BEGIN TRANSACTION`/`COMMIT`/`ROLLBACK` as statements; Neo4j does not
+        // (transactions are driver-level, not Cypher). Analysis passes (concerns, taint,
+        // reflection, config, dynamic-urls) wrap writes in these — no-op them here so those
+        // passes don't fail with Statement.SyntaxError against Neo4j.
+        let trimmed = cypher.trim_end_matches(';').trim();
+        if trimmed.eq_ignore_ascii_case("BEGIN TRANSACTION")
+            || trimmed.eq_ignore_ascii_case("BEGIN")
+            || trimmed.eq_ignore_ascii_case("COMMIT")
+            || trimmed.eq_ignore_ascii_case("ROLLBACK")
+        {
+            return Ok(Vec::new());
+        }
         let keys = parse_return_columns(cypher);
         let rows = self.run_query(query(cypher))?;
         if keys.is_empty() {
@@ -1383,23 +1417,32 @@ impl GraphBackend for Neo4jBackend {
 
         // ── Phase 1: All nodes (File, Module, Symbol, Statement) ─────
 
-        // File nodes — one batch per chunk
+        // File nodes — one batch per chunk. Stamp f.repo from the write namespace so
+        // repo-scoped read queries work (same as upsert_extraction; this is the bulk path
+        // used by group build).
         let file_params: Vec<HashMap<String, String>> = extractions
             .iter()
             .map(|ext| {
                 let mut m = HashMap::new();
                 m.insert("id".into(), ext.file.clone());
                 m.insert("lang".into(), ext.language.clone());
+                if let Some(ns) = &self.write_namespace {
+                    m.insert("repo".into(), ns.clone());
+                }
                 m
             })
             .collect();
+        let file_set = if self.write_namespace.is_some() {
+            "SET file.language = f.lang, file.repo = f.repo"
+        } else {
+            "SET file.language = f.lang"
+        };
         for chunk in file_params.chunks(BATCH_SIZE) {
             self.block_on(
                 self.graph.run(
-                    query(
-                        "UNWIND $batch AS f \
-                     MERGE (file:File {id: f.id}) SET file.language = f.lang",
-                    )
+                    query(&format!(
+                        "UNWIND $batch AS f MERGE (file:File {{id: f.id}}) {file_set}"
+                    ))
                     .param("batch", chunk.to_vec()),
                 ),
             )
@@ -1658,18 +1701,9 @@ impl GraphBackend for Neo4jBackend {
                 .run(query("MERGE (r:Repo {name: $name})").param("name", repo_name)),
         )
         .map_err(|e| anyhow::anyhow!("upsert Repo node failed: {e}"))?;
-        self.block_on(
-            self.graph.run(
-                query(
-                    "MATCH (f:File) \
-                 WHERE (f.repo IS NULL OR f.repo = '') \
-                   AND NOT (f)-[:BELONGS_TO]->(:Repo) \
-                 SET f.repo = $repo",
-                )
-                .param("repo", repo_name),
-            ),
-        )
-        .map_err(|e| anyhow::anyhow!("set file repo failed: {e}"))?;
+        // f.repo is stamped at write time in upsert_extraction. Only link the files that
+        // already belong to THIS repo — never a global unfiltered `MATCH (f:File)`, which
+        // would steal orphan files from every other repo sharing the Neo4j instance.
         self.block_on(
             self.graph.run(
                 query(

--- a/crates/infigraph-core/src/lib.rs
+++ b/crates/infigraph-core/src/lib.rs
@@ -316,6 +316,11 @@ impl Infigraph {
     /// All file paths and symbol IDs will be prefixed with `{namespace}/`.
     pub fn set_namespace(&mut self, ns: &str) {
         self.namespace = Some(ns.to_string());
+        // Mirror to the Neo4j backend so File nodes get f.repo = ns at write time.
+        #[cfg(feature = "neo4j")]
+        if let BackendKind::Neo4j(ref mut neo) = self.backend_kind {
+            neo.set_write_namespace(ns);
+        }
     }
 
     /// Scope Neo4j read queries to a single repo by its directory name.

--- a/crates/infigraph-core/src/multi/mod.rs
+++ b/crates/infigraph-core/src/multi/mod.rs
@@ -158,6 +158,61 @@ impl Registry {
         self.save()
     }
 
+    /// Resolve a user-supplied group name to the actual stored key.
+    /// Tries the name as-is first (already qualified or org-less), then the
+    /// `INFIGRAPH_ORG`-qualified form `org/name`. This lets CLI commands and the
+    /// webhook accept the bare group name even when it was created with an org
+    /// (create stores `org/name`; without this, every later lookup would miss).
+    pub fn resolve_group_key(&self, name: &str) -> String {
+        // 1. Exact match (already-qualified or org-less).
+        if self.groups.contains_key(name) {
+            return name.to_string();
+        }
+        // 2. INFIGRAPH_ORG-qualified form.
+        let qualified = qualified_group_name(&default_org(), name);
+        if self.groups.contains_key(&qualified) {
+            return qualified;
+        }
+        // 3. Unique `<org>/name` match, regardless of INFIGRAPH_ORG. Lets a group
+        //    created with an explicit --org be referenced by its bare name even when
+        //    the env var is unset or set to a different org.
+        let suffix = format!("/{name}");
+        let mut matches = self.groups.keys().filter(|k| k.ends_with(&suffix));
+        if let Some(first) = matches.next() {
+            if matches.next().is_none() {
+                return first.clone();
+            }
+        }
+        name.to_string()
+    }
+
+    /// Resolve the shared-graph namespace (`org/repo`) for a repo on disk, using the
+    /// group registry as the single source of truth for repo identity. Returns `None`
+    /// if the path is not registered in any group.
+    ///
+    /// A standalone remote `index` must use this rather than deriving a namespace from
+    /// the directory name: the latter can disagree with the group's `org/repo` and write
+    /// orphaned, mis-namespaced nodes into the shared graph.
+    pub fn resolve_repo_namespace(&self, path: &Path) -> Option<String> {
+        let want = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+        // Find the registered repo whose canonical path matches.
+        let repo_name = self.repos.iter().find_map(|(name, entry)| {
+            let ep = std::fs::canonicalize(&entry.path).unwrap_or_else(|_| entry.path.clone());
+            if ep == want {
+                Some(name.clone())
+            } else {
+                None
+            }
+        })?;
+        // Find a group containing this repo and use its org for the namespace.
+        let org = self
+            .groups
+            .values()
+            .find(|g| g.repos.contains(&repo_name))
+            .map(|g| g.org.clone())?;
+        Some(qualified_group_name(&org, &repo_name))
+    }
+
     /// Add a repo to a group.
     pub fn group_add(&mut self, group_name: &str, repo_name: &str) -> Result<()> {
         let group = self
@@ -633,6 +688,12 @@ pub fn index_group(
                     format!("{org}/{repo_name}")
                 };
                 prism.set_namespace(&ns);
+                // Scope reads (get_file_hashes / stale-prune) to THIS repo. Without this,
+                // incremental indexing fetches every repo's file hashes from the shared graph
+                // and the stale-file prune deletes all OTHER repos' data. Must match the
+                // write namespace exactly.
+                #[cfg(feature = "neo4j")]
+                prism.set_repo_filter(&ns);
             }
             let result = prism.index()?;
             Ok((
@@ -671,6 +732,16 @@ pub fn index_group(
                 if let Some(backend) = prism.backend() {
                     if let Err(e) = crate::manifest::index_manifests(prism.root(), backend) {
                         eprintln!("[group] manifest indexing failed for '{}': {e}", repo_name);
+                    }
+                    // Create the Repo node + BELONGS_TO edges keyed by the SAME org/repo
+                    // namespace stamped onto f.repo, so read filters and BELONGS_TO agree.
+                    let ns = if org.is_empty() {
+                        repo_name.clone()
+                    } else {
+                        format!("{org}/{repo_name}")
+                    };
+                    if let Err(e) = backend.upsert_repo(&ns) {
+                        eprintln!("[group] repo node creation failed for '{}': {e}", repo_name);
                     }
                 }
 

--- a/crates/infigraph-mcp/src/tools/helpers.rs
+++ b/crates/infigraph-mcp/src/tools/helpers.rs
@@ -84,7 +84,9 @@ pub fn open_prism_read_only(args: &Value) -> Result<Infigraph> {
 }
 
 /// In Neo4j (remote) mode, scope read queries to the repo matching this path.
-/// Derives repo name from the last path component (e.g., `/data/repos/my-svc` → `my-svc`).
+/// Uses the same `org/repo` key that the group write path stamps onto `f.repo`
+/// (bare repo name = last path component, org from `INFIGRAPH_ORG`). Read and write
+/// MUST agree on this key or repo-scoped queries return nothing.
 #[cfg(feature = "remote")]
 fn apply_repo_filter(prism: &mut Infigraph, raw_path: &str) {
     if std::env::var("INFIGRAPH_BACKEND").as_deref() == Ok("neo4j") {
@@ -92,7 +94,13 @@ fn apply_repo_filter(prism: &mut Infigraph, raw_path: &str) {
             .file_name()
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_else(|| raw_path.to_string());
-        prism.set_repo_filter(&repo_name);
+        let org = infigraph_core::multi::default_org();
+        let key = if org.is_empty() {
+            repo_name
+        } else {
+            format!("{org}/{repo_name}")
+        };
+        prism.set_repo_filter(&key);
     }
 }
 

--- a/crates/infigraph-mcp/src/web/mod.rs
+++ b/crates/infigraph-mcp/src/web/mod.rs
@@ -419,23 +419,12 @@ fn handle_webhook_reindex(request: &mut tiny_http::Request) -> Response<std::io:
                     }
                 }
 
-                crate::mcp_log("INFO", &format!("webhook: indexing {repo}"));
-                match Command::new(&bin)
-                    .arg("index")
-                    .current_dir(&repo_path)
-                    .status()
-                {
-                    Ok(s) if s.success() => {}
-                    Ok(s) => {
-                        crate::mcp_log("ERROR", &format!("webhook: index failed (exit {s})"));
-                        result = "partial_failure";
-                    }
-                    Err(e) => {
-                        crate::mcp_log("ERROR", &format!("webhook: index spawn failed: {e}"));
-                        result = "partial_failure";
-                    }
-                }
-
+                // Do NOT run a standalone `infigraph index` here. In shared-Neo4j group mode
+                // that path namespaces by bare repo basename (not org/repo), producing IDs that
+                // don't match the combined graph, and it bumps last_indexed_commit — which makes
+                // the subsequent `group build` treat this repo as unchanged and skip re-indexing
+                // it correctly. `group build` below detects the new HEAD commit and re-indexes
+                // this repo under the correct org/repo namespace on its own.
                 crate::mcp_log("INFO", &format!("webhook: rebuilding group {group}"));
                 match Command::new(&bin).args(["group", "build", &group]).status() {
                     Ok(s) if s.success() => {}

--- a/docs/WEBHOOK-REINDEX.md
+++ b/docs/WEBHOOK-REINDEX.md
@@ -23,8 +23,9 @@ GitHub Enterprise (GHE)
 │                                                 │
 │  Background thread:                             │
 │    ├─ git pull --ff-only <changed repo>         │
-│    ├─ infigraph index <repo>                    │
 │    ├─ infigraph group build <group>             │
+│    │    (reindexes only the changed repo under  │
+│    │     its org/repo namespace; skips others)  │
 │    └─ Log completion + update status            │
 │                                                 │
 │  During reindex: serve from existing graph      │


### PR DESCRIPTION
In shared-Neo4j (remote group) mode a single-repo webhook re-indexed every repo in the group, and combined-graph queries returned 0 while per-repo queries succeeded. Root cause: the read and write paths disagreed on how to identify a repo, plus a Kùzu-only transaction statement leaked into the Neo4j backend.

Fixes:
- webhook: drop the standalone `infigraph index` step; pull + `group build` only. The standalone index namespaced by bare repo name (not org/repo) and bumped last_indexed_commit, so `group build` skipped the changed repo and force-reindexed all others ("commit unchanged but graph empty").
- neo4j: stamp f.repo = org/repo at write time in BOTH write paths (upsert_extraction and the bulk upsert_files_bulk used by group build); remove the global unfiltered `MATCH (f:File) SET f.repo` backfill in upsert_repo that stole orphan files across repos.
- group + standalone index: set_repo_filter alongside set_namespace so get_file_hashes / stale-prune are scoped to the repo being indexed — previously reindexing one repo deleted every other repo's data.
- standalone index in remote mode is now registry-driven: it resolves the repo's org/repo namespace from the group registry and refuses to index a repo not registered in any group, instead of inventing a namespace from the directory name.
- reader: apply_repo_filter derives org/repo (matching the write key).
- neo4j raw_query: no-op BEGIN TRANSACTION/COMMIT/ROLLBACK (valid Kùzu, invalid Cypher) so concern/taint/reflection/config/dynamic-url analysis works in remote mode.
- CLI group commands: resolve a bare group name to its org-qualified key so org-scoped groups — and the webhook's `group build` — actually work.

Bumped to 3.2.3, updated CHANGELOG and the WEBHOOK-REINDEX flow diagram.

Verified live against Docker Neo4j+Postgres with 20 real repos across two orgs (data-mlplatform, finplan-taxplan): combined graph ~12.7k symbols all correctly org/repo-namespaced; a mimicked PR merge reindexed only the changed repo, skipped the other 19, and wiped nothing; a standalone index of one repo left the other 19 intact; an unregistered repo was refused; idempotent no-op webhook skipped all repos; no BEGIN TRANSACTION errors.

## Summary

<!-- What does this PR do? -->

## Test plan

- [ ] `cargo test --all` passes
- [ ] `cargo clippy --all-targets` passes
- [ ] Tested manually (describe below)

## Notes

<!-- Anything reviewers should know? -->
