### PR TITLE
fix: CALLS_SERVICE edge writes use a real transaction instead of BEGIN/COMMIT split across fresh connections

### DIFF
--- a/crates/infigraph-core/src/graph/backend.rs
+++ b/crates/infigraph-core/src/graph/backend.rs
@@ -16,6 +16,17 @@ use super::{
     TestCoverage, TypeHierarchy,
 };
 
+/// A single detected dynamic-URL/route match, to be written as a
+/// `CALLS_SERVICE` edge from the calling symbol to the matched route
+/// handler.
+#[derive(Debug, Clone)]
+pub struct CallsServiceEdge {
+    pub symbol_id: String,
+    pub target_id: String,
+    pub method: String,
+    pub path: String,
+}
+
 /// Backend-agnostic graph storage interface.
 ///
 /// KuzuBackend wraps the existing embedded Kùzu store (local mode).
@@ -127,6 +138,12 @@ pub trait GraphBackend: Send + Sync {
     fn repo_filter(&self) -> Option<&str> {
         None
     }
+
+    /// Write a batch of `CALLS_SERVICE` edges as a single atomic operation.
+    /// Backend owns the transaction — callers don't manage connections
+    /// directly (same design as `upsert_files_bulk`/`resolve_calls`). A
+    /// no-op for an empty slice.
+    fn write_calls_service_edges(&self, edges: &[CallsServiceEdge]) -> Result<()>;
 
     // ── Resolve ──────────────────────────────────────────────────────
 

--- a/crates/infigraph-core/src/graph/kuzu_backend.rs
+++ b/crates/infigraph-core/src/graph/kuzu_backend.rs
@@ -7,7 +7,7 @@ use crate::learned::LearnedStore;
 use crate::model::FileExtraction;
 use crate::resolve::ResolveStats;
 
-use super::backend::GraphBackend;
+use super::backend::{CallsServiceEdge, GraphBackend};
 use super::queries::GraphQuery;
 use super::store::GraphStore;
 use super::{
@@ -455,6 +455,34 @@ impl GraphBackend for KuzuBackend {
 
     fn derive_tested_by_edges(&self, _changed_files: Option<&[&str]>) -> Result<usize> {
         self.store.derive_tested_by_edges()
+    }
+
+    fn write_calls_service_edges(&self, edges: &[CallsServiceEdge]) -> Result<()> {
+        if edges.is_empty() {
+            return Ok(());
+        }
+        let conn = self.store.connection()?;
+        conn.query("BEGIN TRANSACTION")
+            .map_err(|e| anyhow::anyhow!("failed to begin transaction: {e}"))?;
+        for edge in edges {
+            let src_esc = crate::escape_str(&edge.symbol_id);
+            let tgt_esc = crate::escape_str(&edge.target_id);
+            let method_esc = crate::escape_str(&edge.method);
+            let path_esc = crate::escape_str(&edge.path);
+            if let Err(e) = conn.query(&format!(
+                "MATCH (s:Symbol), (t:Symbol) WHERE s.id = '{src_esc}' AND t.id = '{tgt_esc}' \
+                 CREATE (s)-[:CALLS_SERVICE {{method: '{method_esc}', path: '{path_esc}', target_service: ''}}]->(t)"
+            )) {
+                // Roll back so we don't leave a half-applied batch or a
+                // dangling open transaction on this connection, then
+                // surface the real error instead of masking it.
+                let _ = conn.query("ROLLBACK");
+                return Err(anyhow::anyhow!("failed to create CALLS_SERVICE edge: {e}"));
+            }
+        }
+        conn.query("COMMIT")
+            .map_err(|e| anyhow::anyhow!("failed to commit CALLS_SERVICE edges: {e}"))?;
+        Ok(())
     }
 
     // ── Resolve ──────────────────────────────────────────────────────

--- a/crates/infigraph-core/src/graph/mod.rs
+++ b/crates/infigraph-core/src/graph/mod.rs
@@ -15,7 +15,7 @@ pub(crate) mod store_util;
 mod store_write;
 pub mod test_templates;
 
-pub use backend::GraphBackend;
+pub use backend::{CallsServiceEdge, GraphBackend};
 pub use cozo_store::CozoStore;
 pub use kuzu_backend::KuzuBackend;
 #[cfg(feature = "neo4j")]

--- a/crates/infigraph-core/src/graph/neo4j_backend.rs
+++ b/crates/infigraph-core/src/graph/neo4j_backend.rs
@@ -11,7 +11,7 @@ use crate::learned::LearnedStore;
 use crate::model::FileExtraction;
 use crate::resolve::ResolveStats;
 
-use super::backend::GraphBackend;
+use super::backend::{CallsServiceEdge, GraphBackend};
 use super::{
     ApiSymbol, ArchitectureStats, BranchInfo, ComplexityRow, DeadCodeRow, FileDeps, FileHotspot,
     GraphStats, HubFunction, ImpactRow, KindCount, LanguageCount, ReferenceRow, SymbolDetail,
@@ -1698,6 +1698,35 @@ impl GraphBackend for Neo4jBackend {
         }
         let count = self.count_query("MATCH ()-[r:TESTED_BY]->() RETURN count(r) AS c", "c")?;
         Ok(count as usize)
+    }
+
+    fn write_calls_service_edges(&self, edges: &[CallsServiceEdge]) -> Result<()> {
+        if edges.is_empty() {
+            return Ok(());
+        }
+        let edge_maps: Vec<HashMap<&str, String>> = edges
+            .iter()
+            .map(|e| {
+                let mut m = HashMap::new();
+                m.insert("symbol_id", e.symbol_id.clone());
+                m.insert("target_id", e.target_id.clone());
+                m.insert("method", e.method.clone());
+                m.insert("path", e.path.clone());
+                m
+            })
+            .collect();
+        self.block_on(
+            self.graph.run(
+                query(
+                    "UNWIND $edges AS e \
+                     MATCH (s:Symbol), (t:Symbol) WHERE s.id = e.symbol_id AND t.id = e.target_id \
+                     CREATE (s)-[:CALLS_SERVICE {method: e.method, path: e.path, target_service: ''}]->(t)",
+                )
+                .param("edges", edge_maps),
+            ),
+        )
+        .map_err(|e| anyhow::anyhow!("write_calls_service_edges failed: {e}"))?;
+        Ok(())
     }
 
     fn clear_all_data(&self) -> Result<()> {

--- a/crates/infigraph-core/src/taint/dynamic_urls.rs
+++ b/crates/infigraph-core/src/taint/dynamic_urls.rs
@@ -140,9 +140,20 @@ pub fn detect_dynamic_urls(backend: &dyn GraphBackend, root: &Path) -> Result<Ve
         urls.extend(detected);
     }
 
-    if !urls.is_empty() {
-        write_calls_service_edges(backend, &urls)?;
-    }
+    let edges: Vec<crate::graph::CallsServiceEdge> = urls
+        .iter()
+        .filter_map(|url| {
+            url.matched_route
+                .as_ref()
+                .map(|matched| crate::graph::CallsServiceEdge {
+                    symbol_id: url.symbol_id.clone(),
+                    target_id: matched.handler_id.clone(),
+                    method: matched.method.clone(),
+                    path: url.url_template.clone(),
+                })
+        })
+        .collect();
+    backend.write_calls_service_edges(&edges)?;
 
     Ok(urls)
 }
@@ -178,9 +189,20 @@ pub fn detect_dynamic_urls_with_cache(
         urls.extend(detected);
     }
 
-    if !urls.is_empty() {
-        write_calls_service_edges(backend, &urls)?;
-    }
+    let edges: Vec<crate::graph::CallsServiceEdge> = urls
+        .iter()
+        .filter_map(|url| {
+            url.matched_route
+                .as_ref()
+                .map(|matched| crate::graph::CallsServiceEdge {
+                    symbol_id: url.symbol_id.clone(),
+                    target_id: matched.handler_id.clone(),
+                    method: matched.method.clone(),
+                    path: url.url_template.clone(),
+                })
+        })
+        .collect();
+    backend.write_calls_service_edges(&edges)?;
 
     Ok(urls)
 }
@@ -397,28 +419,6 @@ fn match_route(template: &str, routes: &[Route]) -> Option<MatchedRoute> {
     }
 
     None
-}
-
-fn write_calls_service_edges(backend: &dyn GraphBackend, urls: &[DynamicUrl]) -> Result<()> {
-    backend.raw_query("BEGIN TRANSACTION")?;
-
-    for url in urls {
-        if let Some(ref matched) = url.matched_route {
-            let src_esc = crate::escape_str(&url.symbol_id);
-            let tgt_esc = crate::escape_str(&matched.handler_id);
-            let method_esc = crate::escape_str(&matched.method);
-            let path_esc = crate::escape_str(&url.url_template);
-
-            let _ = backend.raw_query(&format!(
-                "MATCH (s:Symbol), (t:Symbol) WHERE s.id = '{src_esc}' AND t.id = '{tgt_esc}' \
-                 CREATE (s)-[:CALLS_SERVICE {{method: '{method_esc}', path: '{path_esc}', target_service: ''}}]->(t)"
-            ));
-        }
-    }
-
-    backend.raw_query("COMMIT")?;
-
-    Ok(())
 }
 
 pub fn format_dynamic_urls(urls: &[DynamicUrl]) -> String {

--- a/crates/infigraph-core/tests/calls_service_edges.rs
+++ b/crates/infigraph-core/tests/calls_service_edges.rs
@@ -1,0 +1,105 @@
+use infigraph_core::graph::{CallsServiceEdge, GraphBackend, KuzuBackend};
+use infigraph_core::model::{FileExtraction, Span, Symbol, SymbolKind};
+
+fn span(file: &str, start: u32, end: u32) -> Span {
+    Span {
+        file: file.to_string(),
+        start_line: start,
+        start_col: 0,
+        end_line: end,
+        end_col: 0,
+    }
+}
+
+fn sym(id: &str, name: &str, file: &str, start: u32, end: u32) -> Symbol {
+    Symbol {
+        id: id.to_string(),
+        name: name.to_string(),
+        kind: SymbolKind::Function,
+        span: span(file, start, end),
+        signature_hash: format!("hash_{id}"),
+        parent: None,
+        language: "python".to_string(),
+        visibility: Some("public".to_string()),
+        docstring: None,
+        complexity: 1,
+        parameters: None,
+        return_type: None,
+    }
+}
+
+fn seed_two_symbols(backend: &KuzuBackend) {
+    let src = FileExtraction {
+        file: "caller.py".to_string(),
+        language: "python".to_string(),
+        content_hash: "h1".to_string(),
+        symbols: vec![sym("caller.py::handler", "handler", "caller.py", 1, 5)],
+        relations: vec![],
+        statements: vec![],
+    };
+    let tgt = FileExtraction {
+        file: "target.py".to_string(),
+        language: "python".to_string(),
+        content_hash: "h2".to_string(),
+        symbols: vec![sym("target.py::endpoint", "endpoint", "target.py", 1, 5)],
+        relations: vec![],
+        statements: vec![],
+    };
+    backend.upsert_file(&src).unwrap();
+    backend.upsert_file(&tgt).unwrap();
+}
+
+/// Regression test for the exact bug found this session: writing more than
+/// one CALLS_SERVICE edge used to fail with "No active transaction for
+/// COMMIT" because BEGIN/CREATE-loop/COMMIT were three separate raw_query
+/// calls, each silently getting its own fresh Kùzu connection. This test
+/// writes two edges (the loop must run more than once for the old bug to
+/// reliably manifest) and asserts both real edges exist afterward.
+#[test]
+fn write_calls_service_edges_creates_all_edges_in_one_call() {
+    let tmp = tempfile::tempdir().unwrap();
+    let backend = KuzuBackend::open(&tmp.path().join("graph")).unwrap();
+    seed_two_symbols(&backend);
+
+    let edges = vec![
+        CallsServiceEdge {
+            symbol_id: "caller.py::handler".to_string(),
+            target_id: "target.py::endpoint".to_string(),
+            method: "GET".to_string(),
+            path: "/api/one".to_string(),
+        },
+        CallsServiceEdge {
+            symbol_id: "caller.py::handler".to_string(),
+            target_id: "target.py::endpoint".to_string(),
+            method: "POST".to_string(),
+            path: "/api/two".to_string(),
+        },
+    ];
+
+    backend.write_calls_service_edges(&edges).expect(
+        "write_calls_service_edges must succeed, not fail with 'No active transaction for COMMIT'",
+    );
+
+    let rows = backend
+        .raw_query("MATCH (:Symbol)-[r:CALLS_SERVICE]->(:Symbol) RETURN r.method, r.path ORDER BY r.method")
+        .unwrap();
+    assert_eq!(
+        rows.len(),
+        2,
+        "expected both edges to be created, got {rows:?}"
+    );
+    assert_eq!(rows[0][0], "GET");
+    assert_eq!(rows[0][1], "/api/one");
+    assert_eq!(rows[1][0], "POST");
+    assert_eq!(rows[1][1], "/api/two");
+}
+
+/// Empty input must not error (matches the old code's behavior — the old
+/// function's caller only invoked it when `!urls.is_empty()`, but the new
+/// trait method should be safe to call with zero edges regardless).
+#[test]
+fn write_calls_service_edges_empty_is_a_noop() {
+    let tmp = tempfile::tempdir().unwrap();
+    let backend = KuzuBackend::open(&tmp.path().join("graph")).unwrap();
+    backend.write_calls_service_edges(&[]).unwrap();
+}

--- a/crates/infigraph-core/tests/neo4j_backend.rs
+++ b/crates/infigraph-core/tests/neo4j_backend.rs
@@ -8,7 +8,7 @@
 
 #![cfg(feature = "neo4j")]
 
-use infigraph_core::graph::{GraphBackend, Neo4jBackend};
+use infigraph_core::graph::{CallsServiceEdge, GraphBackend, Neo4jBackend};
 use infigraph_core::model::{FileExtraction, Relation, RelationKind, Span, Symbol, SymbolKind};
 
 fn span(file: &str, start: u32, end: u32) -> Span {
@@ -291,6 +291,97 @@ fn test_neo4j_raw_query() {
         .raw_query("MATCH (s:Symbol) RETURN s.name ORDER BY s.name")
         .expect("raw");
     assert_eq!(rows.len(), 3);
+}
+
+// ── CALLS_SERVICE edge tests ──────────────────────────────────────────
+
+fn seed_two_symbols(backend: &Neo4jBackend) {
+    let extractions = vec![
+        FileExtraction {
+            file: "caller.py".to_string(),
+            language: "python".to_string(),
+            content_hash: "h1".to_string(),
+            symbols: vec![sym(
+                "caller.py::handler",
+                "handler",
+                SymbolKind::Function,
+                "caller.py",
+                1,
+                5,
+            )],
+            relations: vec![],
+            statements: vec![],
+        },
+        FileExtraction {
+            file: "target.py".to_string(),
+            language: "python".to_string(),
+            content_hash: "h2".to_string(),
+            symbols: vec![sym(
+                "target.py::endpoint",
+                "endpoint",
+                SymbolKind::Function,
+                "target.py",
+                1,
+                5,
+            )],
+            relations: vec![],
+            statements: vec![],
+        },
+    ];
+    backend
+        .upsert_files_bulk(&extractions, true)
+        .expect("seed bulk");
+}
+
+#[test]
+#[ignore]
+fn test_neo4j_write_calls_service_edges_creates_all_edges_in_one_call() {
+    let backend = connect();
+    clear_graph(&backend);
+    seed_two_symbols(&backend);
+
+    let edges = vec![
+        CallsServiceEdge {
+            symbol_id: "caller.py::handler".to_string(),
+            target_id: "target.py::endpoint".to_string(),
+            method: "GET".to_string(),
+            path: "/api/one".to_string(),
+        },
+        CallsServiceEdge {
+            symbol_id: "caller.py::handler".to_string(),
+            target_id: "target.py::endpoint".to_string(),
+            method: "POST".to_string(),
+            path: "/api/two".to_string(),
+        },
+    ];
+
+    backend.write_calls_service_edges(&edges).expect(
+        "write_calls_service_edges must succeed, not fail with 'No active transaction for COMMIT'",
+    );
+
+    let rows = backend
+        .raw_query(
+            "MATCH (:Symbol)-[r:CALLS_SERVICE]->(:Symbol) RETURN r.method, r.path ORDER BY r.method",
+        )
+        .expect("raw");
+    assert_eq!(
+        rows.len(),
+        2,
+        "expected both edges to be created, got {rows:?}"
+    );
+    assert_eq!(rows[0][0], "GET");
+    assert_eq!(rows[0][1], "/api/one");
+    assert_eq!(rows[1][0], "POST");
+    assert_eq!(rows[1][1], "/api/two");
+}
+
+#[test]
+#[ignore]
+fn test_neo4j_write_calls_service_edges_empty_is_a_noop() {
+    let backend = connect();
+    clear_graph(&backend);
+
+    backend.write_calls_service_edges(&[]).expect("empty noop");
 }
 
 // ── Namespace isolation tests ────────────────────────────────────────


### PR DESCRIPTION
`detect_dynamic_urls`'s CALLS_SERVICE edge writer issued `BEGIN TRANSACTION`/`CREATE`/`COMMIT` as three separate `raw_query` calls — but `GraphBackend::raw_query` (Kùzu) opens a fresh `Connection` on every call, so the transaction never actually spanned the writes. `COMMIT` reliably failed with "No active transaction for COMMIT" whenever any edge was written (silently caught as a non-fatal warning, so this went unnoticed — confirmed by reproducing it against this repo's own `crates/` tree during investigation).

Moved the write onto a new `GraphBackend::write_calls_service_edges` trait method that owns its own transaction/connection internally, matching every other multi-step write already in the trait (`upsert_files_bulk`, `derive_tested_by_edges`, `resolve_calls`). Implemented for real in both `KuzuBackend` (one held connection, correct BEGIN/loop/COMMIT with rollback on error) and `Neo4jBackend` (single UNWIND-parameterized query, auto-committed) — a no-op default would have silently dropped these edges for whichever backend didn't get a real implementation, so both ship together here.

One incidental behavior change worth calling out: the old code silently swallowed every per-row CREATE failure (`let _ = ...`); the new code surfaces per-row errors and rolls back the batch on failure, making the write atomic per pass. The caller (`crates/infigraph-mcp/src/tools/index.rs`) already treats a returned `Err` as a non-fatal warning, so this is a pure improvement with no regression risk.

Also fixes the incidental per-edge connection-construction overhead this pattern caused (one connection for the whole batch instead of N+2).

## Test plan
- [x] `cargo test -p infigraph-core --test calls_service_edges` — new regression test reproduces the original multi-edge failure mode and asserts it's fixed
- [x] `cargo test -p infigraph-core --features neo4j --test neo4j_backend` — 17/17 passing against a live Neo4j, including 2 new tests for the Neo4j implementation
- [x] Full default-feature suite (`infigraph-core`/`infigraph-cli`/`infigraph-mcp`) — clean modulo pre-existing, unrelated flakes confirmed via base-commit comparison
- [x] `--features remote` build + clippy — clean (pre-existing clippy findings elsewhere in the file confirmed byte-identical on the base commit, unrelated to this diff)
- [x] `cargo fmt --all -- --check` — clean
- [x] Manual smoke test: indexed this repo's own `crates/` (13 dynamic URLs detected, 6 matched to routes) — no "no active transaction" warning, and the graph was queried directly to confirm all 6 `CALLS_SERVICE` edges were actually committed