### PR TITLE
fix: SCIP symbol-name and enrichment correctness (parameter descriptor pollution, span/name/enrichment)

### DIFF
--- a/crates/infigraph-core/src/scip/mod.rs
+++ b/crates/infigraph-core/src/scip/mod.rs
@@ -105,7 +105,15 @@ pub fn import_scip_index(
     }
 
     // Pass 1: collect enrichments and new symbols in memory
-    let mut enrichments: Vec<(String, u32, u32, String)> = Vec::new();
+    //
+    // Enrichments only ever update `docstring`. Existing symbols already
+    // have a correct start_line/end_line from tree-sitter's full-body AST
+    // extraction; a SCIP definition occurrence's range is the span of the
+    // identifier token itself, not the enclosing declaration, so it must
+    // never be written back over the tree-sitter-derived span (previously
+    // it was, silently collapsing every enriched symbol's displayed source
+    // to ~1 line).
+    let mut enrichments: Vec<(String, String)> = Vec::new();
     let mut new_symbols: Vec<(String, String, String, String, u32, u32, String)> = Vec::new();
 
     for doc in &index.documents {
@@ -137,12 +145,7 @@ pub fn import_scip_index(
             let key = (file.clone(), name.clone());
             if let Some(ids) = file_name_to_ids.get(&key) {
                 for sid in ids {
-                    enrichments.push((
-                        sid.clone(),
-                        span.start_line,
-                        span.end_line,
-                        docstring.to_string(),
-                    ));
+                    enrichments.push((sid.clone(), docstring.to_string()));
                     stats.symbols_enriched += 1;
                 }
             } else {
@@ -286,22 +289,16 @@ pub fn import_scip_index(
         let _ = std::fs::remove_file(&sym_pq);
     }
 
-    // Bulk write enrichments via UNWIND (updates can't use COPY FROM)
+    // Bulk write enrichments via UNWIND (updates can't use COPY FROM).
+    // Only docstring is enriched -- see the note on `enrichments` above for
+    // why start_line/end_line must never be written here.
     for chunk in enrichments.chunks(CHUNK) {
         let rows: Vec<String> = chunk
             .iter()
-            .map(|(id, start, end, doc)| {
-                format!(
-                    "{{id: '{}', sl: {}, el: {}, doc: '{}'}}",
-                    escape(id),
-                    start,
-                    end,
-                    escape(doc)
-                )
-            })
+            .map(|(id, doc)| format!("{{id: '{}', doc: '{}'}}", escape(id), escape(doc)))
             .collect();
         let _ = conn.query(&format!(
-            "UNWIND [{}] AS e MATCH (s:Symbol) WHERE s.id = e.id SET s.start_line = e.sl, s.end_line = e.el, s.docstring = e.doc",
+            "UNWIND [{}] AS e MATCH (s:Symbol) WHERE s.id = e.id SET s.docstring = e.doc",
             rows.join(", ")
         ));
     }
@@ -769,6 +766,74 @@ mod tests {
         assert_eq!(
             scip_sym_to_name("scip-python python test-pkg 1.0.0 `test`/Animal#"),
             "Animal"
+        );
+    }
+
+    #[test]
+    fn enrichment_does_not_overwrite_existing_symbol_span() {
+        let env = TestEnv::new();
+        let conn = env.store.connection().unwrap();
+
+        // Simulate tree-sitter's correct full-body extraction: a function
+        // spanning lines 10-50.
+        conn.query(
+            "CREATE (:Symbol {id: 'test.ts::widen', name: 'widen', kind: 'function', \
+             file: 'test.ts', start_line: 10, end_line: 50, signature_hash: '', \
+             language: 'typescript', visibility: 'public', parent: '', docstring: '', \
+             complexity: 0, parameters: '', return_type: ''})",
+        )
+        .unwrap();
+
+        // SCIP's definition occurrence for the same symbol only spans the
+        // identifier token itself (a single line) -- never the full body.
+        let sym = scip_symbol("widen", "test.ts");
+        let doc = Document {
+            relative_path: "test.ts".to_string(),
+            occurrences: vec![Occurrence {
+                range: vec![9, 9, 9, 14], // 0-based line 9 == 1-based line 10
+                symbol: sym.clone(),
+                symbol_roles: SymbolRole::Definition as i32,
+                ..Default::default()
+            }],
+            symbols: vec![SymbolInformation {
+                symbol: sym,
+                documentation: vec!["Widens a value.".to_string()],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let index = Index {
+            documents: vec![doc],
+            ..Default::default()
+        };
+        let bytes = index.write_to_bytes().unwrap();
+        let index_path = env._dir.path().join("index.scip");
+        std::fs::write(&index_path, bytes).unwrap();
+
+        let stats = import_scip_index(&index_path, &env.store, None).unwrap();
+        assert_eq!(stats.symbols_enriched, 1, "enrichment path must have run");
+
+        let rows = conn
+            .query(
+                "MATCH (s:Symbol {id: 'test.ts::widen'}) RETURN s.start_line, s.end_line, s.docstring",
+            )
+            .unwrap();
+        let row = rows.into_iter().next().expect("symbol must still exist");
+        let start: i64 = row[0].to_string().parse().unwrap();
+        let end: i64 = row[1].to_string().parse().unwrap();
+        let docstring = row[2].to_string().trim_matches('"').to_string();
+
+        assert_eq!(
+            start, 10,
+            "SCIP enrichment must not overwrite the existing full-body start_line with the narrow definition-occurrence range"
+        );
+        assert_eq!(
+            end, 50,
+            "SCIP enrichment must not overwrite the existing full-body end_line with the narrow definition-occurrence range"
+        );
+        assert_eq!(
+            docstring, "Widens a value.",
+            "docstring enrichment should still apply"
         );
     }
 }

--- a/crates/infigraph-core/src/scip/mod.rs
+++ b/crates/infigraph-core/src/scip/mod.rs
@@ -13,6 +13,34 @@ use crate::graph::store_util::{escape, fwd_slash_path, unwind_edges_from_pairs};
 use crate::graph::GraphStore;
 use crate::model::{Span, SymbolKind};
 
+/// True when `scip_sym` is a member (e.g. a parameter) of a symbol we
+/// already know about, per SCIP's own descriptor grammar: strip a single
+/// trailing `(...)` group and check whether what remains is a moniker
+/// already present in `known` (built from every other non-local
+/// definition occurrence in this same import pass, before this check
+/// ever runs -- see `scip_sym_to_file_name`, populated before Pass 1).
+///
+/// Verified against real `scip-typescript` output: a parameter's moniker
+/// is exactly its enclosing method's own moniker (always ending in `.`)
+/// with `(paramName)` appended -- nothing else -- so this is an exact
+/// string match against already-known data, not a re-derived heuristic.
+/// Deliberately does NOT use `SymbolInformation.kind`: verified always
+/// `UnspecifiedKind` in real output, so it carries no usable signal.
+///
+/// A normal top-level definition's own moniker always ends in `.` (Term),
+/// `#` (Type), or `().` (Method) per SCIP's descriptor grammar -- never a
+/// bare `)` -- so this never fires for a legitimately-new symbol; it can
+/// only match nested member descriptors.
+fn is_member_of_known_symbol(scip_sym: &str, known: &HashMap<String, (String, String)>) -> bool {
+    let Some(without_group) = scip_sym.strip_suffix(')') else {
+        return false;
+    };
+    let Some(open) = without_group.rfind('(') else {
+        return false;
+    };
+    known.contains_key(&without_group[..open])
+}
+
 /// Import a SCIP index.scip file into the Infigraph graph store.
 ///
 /// Matches SCIP definitions to existing tree-sitter symbols by (file, name)
@@ -131,6 +159,9 @@ pub fn import_scip_index(
             }
             let scip_sym = &occ.symbol;
             if scip_sym.starts_with("local ") || scip_sym.starts_with('<') {
+                continue;
+            }
+            if is_member_of_known_symbol(scip_sym, &scip_sym_to_file_name) {
                 continue;
             }
 
@@ -834,6 +865,188 @@ mod tests {
         assert_eq!(
             docstring, "Widens a value.",
             "docstring enrichment should still apply"
+        );
+    }
+
+    #[test]
+    fn scip_parameter_descriptor_does_not_become_a_new_symbol() {
+        let env = TestEnv::new();
+        let file = "test.ts";
+        // Real scip-typescript shape, verified against real output: a
+        // parameter's moniker is exactly its enclosing method's own moniker
+        // (always ending in `.`) with `(paramName)` appended.
+        let method_sym = "scip-test npm test 1.0.0 `test.ts`/mintFn().".to_string();
+        let param_sym = "scip-test npm test 1.0.0 `test.ts`/mintFn().(rulesBag)".to_string();
+
+        let doc = Document {
+            relative_path: file.to_string(),
+            occurrences: vec![
+                Occurrence {
+                    range: vec![0, 16, 22],
+                    symbol: method_sym.clone(),
+                    symbol_roles: SymbolRole::Definition as i32,
+                    ..Default::default()
+                },
+                Occurrence {
+                    range: vec![0, 23, 31],
+                    symbol: param_sym.clone(),
+                    symbol_roles: SymbolRole::Definition as i32,
+                    ..Default::default()
+                },
+            ],
+            symbols: vec![
+                SymbolInformation {
+                    symbol: method_sym.clone(),
+                    ..Default::default()
+                },
+                SymbolInformation {
+                    symbol: param_sym.clone(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        let index = Index {
+            documents: vec![doc],
+            ..Default::default()
+        };
+        let bytes = index.write_to_bytes().unwrap();
+        let index_path = env._dir.path().join("index.scip");
+        std::fs::write(&index_path, bytes).unwrap();
+
+        let stats = import_scip_index(&index_path, &env.store, None).unwrap();
+        assert_eq!(
+            stats.symbols_added, 1,
+            "only the method itself should become a new symbol -- the parameter must be suppressed"
+        );
+
+        let conn = env.store.connection().unwrap();
+        let rows = conn.query("MATCH (s:Symbol) RETURN s.name").unwrap();
+        let names: Vec<String> = rows
+            .into_iter()
+            .map(|row| row[0].to_string().trim_matches('"').to_string())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["mintFn".to_string()],
+            "no node should exist for the parameter descriptor, and its name must not \
+             leak through as a raw unparsed moniker on any node"
+        );
+    }
+
+    #[test]
+    fn calls_edge_still_attributes_to_enclosing_method_when_a_parameter_is_suppressed() {
+        let env = TestEnv::new();
+        let conn = env.store.connection().unwrap();
+
+        // Seed two pre-existing tree-sitter symbols with real full-body
+        // spans, the normal case: SCIP enriches an already-known function,
+        // it doesn't need to add it.
+        conn.query(
+            "CREATE (:Symbol {id: 'test.ts::mintFn', name: 'mintFn', kind: 'function', \
+             file: 'test.ts', start_line: 1, end_line: 10, signature_hash: '', \
+             language: 'typescript', visibility: 'public', parent: '', docstring: '', \
+             complexity: 0, parameters: '', return_type: ''})",
+        )
+        .unwrap();
+        conn.query(
+            "CREATE (:Symbol {id: 'test.ts::helper', name: 'helper', kind: 'function', \
+             file: 'test.ts', start_line: 20, end_line: 25, signature_hash: '', \
+             language: 'typescript', visibility: 'public', parent: '', docstring: '', \
+             complexity: 0, parameters: '', return_type: ''})",
+        )
+        .unwrap();
+
+        let file = "test.ts";
+        let method_sym = "scip-test npm test 1.0.0 `test.ts`/mintFn().".to_string();
+        let param_sym = "scip-test npm test 1.0.0 `test.ts`/mintFn().(rulesBag)".to_string();
+        let helper_sym = "scip-test npm test 1.0.0 `test.ts`/helper().".to_string();
+
+        let doc = Document {
+            relative_path: file.to_string(),
+            occurrences: vec![
+                // mintFn's own definition occurrence (identifier token only,
+                // line 0 == 1-based line 1, matching the seeded start_line).
+                Occurrence {
+                    range: vec![0, 16, 22],
+                    symbol: method_sym.clone(),
+                    symbol_roles: SymbolRole::Definition as i32,
+                    ..Default::default()
+                },
+                // Its parameter -- must be suppressed, not create a node
+                // that could steal container_id for the reference below.
+                Occurrence {
+                    range: vec![0, 23, 31],
+                    symbol: param_sym.clone(),
+                    symbol_roles: SymbolRole::Definition as i32,
+                    ..Default::default()
+                },
+                // helper's own definition occurrence (1-based line 20).
+                Occurrence {
+                    range: vec![19, 9, 15],
+                    symbol: helper_sym.clone(),
+                    symbol_roles: SymbolRole::Definition as i32,
+                    ..Default::default()
+                },
+                // A reference to helper() from inside mintFn's body (line 4,
+                // 0-based -> 1-based line 5, within mintFn's seeded [1,10]
+                // span and nowhere near the suppressed parameter's own
+                // narrow single-line range).
+                Occurrence {
+                    range: vec![4, 2, 8],
+                    symbol: helper_sym.clone(),
+                    symbol_roles: 0, // reference, not definition
+                    ..Default::default()
+                },
+            ],
+            symbols: vec![
+                SymbolInformation {
+                    symbol: method_sym.clone(),
+                    ..Default::default()
+                },
+                SymbolInformation {
+                    symbol: param_sym.clone(),
+                    ..Default::default()
+                },
+                SymbolInformation {
+                    symbol: helper_sym.clone(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        let index = Index {
+            documents: vec![doc],
+            ..Default::default()
+        };
+        let bytes = index.write_to_bytes().unwrap();
+        let index_path = env._dir.path().join("index.scip");
+        std::fs::write(&index_path, bytes).unwrap();
+
+        let stats = import_scip_index(&index_path, &env.store, None).unwrap();
+        assert_eq!(
+            stats.symbols_added, 0,
+            "both mintFn and helper already exist -- only enrichment, and the \
+             parameter must be suppressed, not added"
+        );
+
+        let rows = conn
+            .query("MATCH (a:Symbol)-[:CALLS]->(b:Symbol) RETURN a.name, b.name")
+            .unwrap();
+        let pairs: Vec<(String, String)> = rows
+            .into_iter()
+            .map(|row| {
+                (
+                    row[0].to_string().trim_matches('"').to_string(),
+                    row[1].to_string().trim_matches('"').to_string(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            pairs,
+            vec![("mintFn".to_string(), "helper".to_string())],
+            "the CALLS edge must attribute to the real enclosing method, not be \
+             dropped or misattributed to a suppressed parameter pseudo-symbol"
         );
     }
 }

--- a/crates/infigraph-core/src/scip/mod.rs
+++ b/crates/infigraph-core/src/scip/mod.rs
@@ -508,14 +508,47 @@ fn parse_range(range: &[i32], file: &str) -> Span {
     }
 }
 
+/// Extract the display name of the last descriptor in a SCIP symbol string.
+///
+/// SCIP symbols end with a chain of `<name><suffix>` descriptors (suffix is one
+/// of `.` term, `#` type, `/` namespace, `:` macro, or `(...)`.` method with an
+/// optional disambiguator) and the suffix is the literal last character, e.g.
+/// `rust-analyzer cargo sittir-core 0.0.0 is_allowed_node_key().` or `.../crate/`.
+/// The suffix must be stripped *before* looking for the name, otherwise it reads
+/// as trailing empty text.
 fn scip_sym_to_name(scip_sym: &str) -> String {
-    scip_sym
-        .rsplit_once('`')
-        .map(|(_, n)| n)
-        .or_else(|| scip_sym.rsplit(['#', '.', '/']).next())
-        .unwrap_or(scip_sym)
-        .trim_matches(|c| c == '(' || c == ')' || c == '`')
-        .to_string()
+    let mut s = scip_sym.trim_end();
+
+    // Strip a trailing method terminator, then its `(...)` disambiguator group.
+    if let Some(rest) = s.strip_suffix('.') {
+        s = rest;
+    }
+    if s.ends_with(')') {
+        if let Some(open) = s.rfind('(') {
+            s = &s[..open];
+        }
+    }
+
+    // Strip a single trailing suffix marker (type/namespace/macro/term).
+    let s = s.trim_end_matches(['#', '/', ':', '.']);
+
+    // Backtick-quoted descriptor name: `Name`
+    if let Some(rest) = s.strip_suffix('`') {
+        if let Some(start) = rest.rfind('`') {
+            return rest[start + 1..].to_string();
+        }
+    }
+
+    // Bare identifier: trailing run of alphanumeric/underscore characters.
+    let ident_start = s
+        .rfind(|c: char| !(c.is_alphanumeric() || c == '_'))
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    if ident_start < s.len() {
+        s[ident_start..].to_string()
+    } else {
+        scip_sym.to_string()
+    }
 }
 
 fn scip_kind_to_prism(kind: &symbol_information::Kind) -> SymbolKind {
@@ -703,5 +736,39 @@ mod tests {
             .query("MATCH (a:Symbol)-[:INHERITS]->(b:Symbol) RETURN a.name, b.name")
             .unwrap();
         assert!(rows.into_iter().next().is_none());
+    }
+
+    #[test]
+    fn scip_sym_to_name_strips_trailing_suffix_markers() {
+        // Real rust-analyzer output: suffix char is the literal last byte.
+        assert_eq!(
+            scip_sym_to_name("rust-analyzer cargo sittir-core 0.0.0 crate/"),
+            "crate"
+        );
+        assert_eq!(
+            scip_sym_to_name("rust-analyzer cargo sittir-core 0.0.0 K_IDENTIFIER."),
+            "K_IDENTIFIER"
+        );
+        assert_eq!(
+            scip_sym_to_name("rust-analyzer cargo sittir-core 0.0.0 is_allowed_node_key()."),
+            "is_allowed_node_key"
+        );
+        assert_eq!(
+            scip_sym_to_name("rust-analyzer cargo sittir-core 0.0.0 SomeTrait#method()."),
+            "method"
+        );
+    }
+
+    #[test]
+    fn scip_sym_to_name_handles_backtick_quoted_descriptors() {
+        // Real scip-typescript output: file-path descriptors are backtick-quoted.
+        assert_eq!(
+            scip_sym_to_name("scip-typescript npm test 1.0.0 `test.ts`/Animal#"),
+            "Animal"
+        );
+        assert_eq!(
+            scip_sym_to_name("scip-python python test-pkg 1.0.0 `test`/Animal#"),
+            "Animal"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Three related fixes to SCIP import correctness in `crates/infigraph-core/src/scip/mod.rs`, found while investigating spurious/ugly entries in `get_doc_context` output:

1. **`scip_sym_to_name` returned empty/wrong names for most real SCIP symbols.** The old implementation split on suffix characters (`.`, `#`, `/`, `:`) without first stripping the trailing suffix marker itself, so it frequently returned an empty string or included the marker. Rewritten to strip the trailing terminator/disambiguator group first, then extract the name, with explicit handling for backtick-quoted descriptors (`` `test.ts`/Animal# ``) and bare identifiers.

2. **SCIP enrichment overwrote existing symbols' `start_line`/`end_line`.** A SCIP definition occurrence's range is the span of the identifier token itself, not the enclosing declaration — but enrichment was writing that narrow range back over the existing symbol's correct full-body span (already established by tree-sitter's AST extraction), silently collapsing every enriched symbol's displayed source to ~1 line. Enrichment now only ever updates `docstring`.

3. **Parameter/member descriptors were becoming spurious top-level graph symbols.** A simple function parameter's SCIP moniker is `<enclosing-method-moniker-ending-in-.>.(paramName)` — no `local ` prefix, so it bypassed the existing local-symbol filter and was created as its own (incorrectly named, since it depends on fix #1) graph node. Root-caused against real `@sourcegraph/scip-typescript` 0.4.0 output; `SymbolInformation.kind` was verified to always be `UnspecifiedKind` in real output, so a `kind`-based filter wasn't viable. Fixed with a structural check (`is_member_of_known_symbol`) that strips a trailing `(...)` descriptor group and checks whether what remains is already a known symbol from this same import pass — this exploits SCIP's own Parameter-descriptor grammar directly, so it should generalize across every SCIP indexer, not just TypeScript's.

Each fix is independently tested; #3 was verified to not affect CALLS-edge resolution (Pass 2) or INHERITS-edge resolution via relationships (Pass 3) — traced through both passes to confirm a suppressed parameter symbol cleanly fails to resolve as a reference target rather than dangling or misattributing an edge.

## Test plan

- [x] `cargo test -p infigraph-core --lib scip::` — 7/7 pass (all new + pre-existing tests)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p infigraph-core --all-targets -- -D warnings` — clean
- [x] Verified end-to-end against a real indexed TypeScript sample

🤖 Generated with [Claude Code](https://claude.com/claude-code)