### PR TITLE
fix: Symbol.parameters/return_type extraction for Kotlin and Dart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2492,6 +2492,7 @@ dependencies = [
  "tokio-postgres",
  "toml",
  "tree-sitter",
+ "tree-sitter-dart",
  "tree-sitter-kotlin-ng",
  "tree-sitter-python",
  "ureq 2.12.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2492,6 +2492,7 @@ dependencies = [
  "tokio-postgres",
  "toml",
  "tree-sitter",
+ "tree-sitter-kotlin-ng",
  "tree-sitter-python",
  "ureq 2.12.1",
  "usearch",

--- a/crates/infigraph-core/Cargo.toml
+++ b/crates/infigraph-core/Cargo.toml
@@ -67,6 +67,7 @@ optional = true
 
 [dev-dependencies]
 tree-sitter-python = "0.25"
+tree-sitter-kotlin-ng = "1.1"
 cargo-husky = { version = "1", default-features = false, features = ["user-hooks"] }
 # Dev-dep cycle (infigraph-languages -> infigraph-core) is fine: dev-deps are excluded
 # from the normal build graph. Needed so remote_cross_service.rs can index real

--- a/crates/infigraph-core/Cargo.toml
+++ b/crates/infigraph-core/Cargo.toml
@@ -68,6 +68,7 @@ optional = true
 [dev-dependencies]
 tree-sitter-python = "0.25"
 tree-sitter-kotlin-ng = "1.1"
+tree-sitter-dart = "0.2"
 cargo-husky = { version = "1", default-features = false, features = ["user-hooks"] }
 # Dev-dep cycle (infigraph-languages -> infigraph-core) is fine: dev-deps are excluded
 # from the normal build graph. Needed so remote_cross_service.rs can index real

--- a/crates/infigraph-core/src/extract/entities.rs
+++ b/crates/infigraph-core/src/extract/entities.rs
@@ -920,6 +920,113 @@ mod tests {
     }
 
     #[test]
+    fn test_dart_function_extracts_parameters_and_return_type() {
+        // tree-sitter-dart's function_signature DOES have real "parameters"/
+        // "return_type" named fields -- but they're one level below the
+        // captured function_declaration node (reached via its "signature"
+        // field), so extract_child_text's direct child_by_field_name lookup
+        // on the outer node misses them. Verified against the crate's real
+        // node-types.json before writing this test.
+        let grammar = tree_sitter_dart::LANGUAGE.into();
+        let src = b"String greet(String name, int age) {\n  return 'hello';\n}\n";
+        let mut parser = Parser::new();
+        parser.set_language(&grammar).unwrap();
+        let tree = parser.parse(src, None).unwrap();
+        let root = tree.root_node();
+
+        let query = tree_sitter::Query::new(
+            &grammar,
+            "(function_declaration\n  \
+               signature: (function_signature\n    \
+                 return_type: (type)? @func.return_type\n    \
+                 name: (identifier) @func.name\n    \
+                 parameters: (formal_parameter_list) @func.params)) @func.def",
+        )
+        .unwrap();
+
+        let symbols = extract_entities("greet.dart", src, root, &query, "dart");
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "greet");
+        assert!(
+            symbols[0].parameters.is_some(),
+            "parameters should be extracted via the @func.params capture"
+        );
+        assert!(
+            symbols[0].parameters.as_deref().unwrap().contains("name"),
+            "parameters should contain param names: {:?}",
+            symbols[0].parameters
+        );
+        assert_eq!(symbols[0].return_type.as_deref(), Some("String"));
+    }
+
+    #[test]
+    fn test_dart_method_extracts_parameters_and_return_type() {
+        // method_signature has ZERO named fields at all (verified against
+        // node-types.json) -- structurally unreachable via child_by_field_name
+        // from the captured node regardless of nesting depth, unlike the
+        // top-level function case which is merely "one level too shallow".
+        let grammar = tree_sitter_dart::LANGUAGE.into();
+        let src =
+            b"class Greeter {\n  String greet(String name, int age) {\n    return 'hi';\n  }\n}\n";
+        let mut parser = Parser::new();
+        parser.set_language(&grammar).unwrap();
+        let tree = parser.parse(src, None).unwrap();
+        let root = tree.root_node();
+
+        let query = tree_sitter::Query::new(
+            &grammar,
+            "(method_signature\n  \
+               (function_signature\n    \
+                 return_type: (type)? @method.return_type\n    \
+                 name: (identifier) @method.name\n    \
+                 parameters: (formal_parameter_list) @method.params)) @method.def",
+        )
+        .unwrap();
+
+        let symbols = extract_entities("greeter.dart", src, root, &query, "dart");
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "greet");
+        assert!(
+            symbols[0].parameters.is_some(),
+            "parameters should be extracted for Dart methods too, not just top-level functions"
+        );
+        assert!(
+            symbols[0].parameters.as_deref().unwrap().contains("name"),
+            "parameters should contain param names: {:?}",
+            symbols[0].parameters
+        );
+        assert_eq!(symbols[0].return_type.as_deref(), Some("String"));
+    }
+
+    #[test]
+    fn test_dart_constructor_still_works_unchanged() {
+        // constructor_signature has direct name+parameters fields, no
+        // nesting -- already worked before this plan and must keep working,
+        // using the existing child_by_field_name fallback (no @method.params
+        // capture needed or added for constructors).
+        let grammar = tree_sitter_dart::LANGUAGE.into();
+        let src = b"class Greeter {\n  Greeter(String name, int age);\n}\n";
+        let mut parser = Parser::new();
+        parser.set_language(&grammar).unwrap();
+        let tree = parser.parse(src, None).unwrap();
+        let root = tree.root_node();
+
+        let query = tree_sitter::Query::new(
+            &grammar,
+            "(constructor_signature name: (identifier) @method.name) @method.def",
+        )
+        .unwrap();
+
+        let symbols = extract_entities("greeter.dart", src, root, &query, "dart");
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "Greeter");
+        assert!(
+            symbols[0].parameters.is_some(),
+            "constructor parameters must still work via the pre-existing fallback"
+        );
+    }
+
+    #[test]
     fn test_is_test_by_name_and_path_go() {
         assert!(is_test_by_name_and_path(
             "TestFoo",

--- a/crates/infigraph-core/src/extract/entities.rs
+++ b/crates/infigraph-core/src/extract/entities.rs
@@ -8,7 +8,11 @@ use crate::model::{Span, Symbol, SymbolKind};
 ///
 /// The query must use these capture names:
 ///   @func.def / @func.name / @func.docstring / @func.decorator
+///   @func.params / @func.return_type (both optional -- only needed when a
+///     grammar doesn't expose "parameters"/"return_type"/"result" as named
+///     fields on the captured @func.def node; see Kotlin/Dart for examples)
 ///   @method.def / @method.name / @method.docstring / @method.decorator
+///   @method.params / @method.return_type (same as @func.params/@func.return_type)
 ///   @class.def / @class.name / @class.docstring / @class.decorator
 ///   @module.def / @module.name
 ///   @test.def / @test.name / @test.docstring
@@ -34,6 +38,8 @@ pub fn extract_entities(
         let mut kind = None;
         let mut docstring = None;
         let mut decorator = None;
+        let mut params_capture: Option<String> = None;
+        let mut return_type_capture: Option<String> = None;
         let mut route_method: Option<String> = None;
         let mut route_path: Option<String> = None;
         let mut route_handler: Option<String> = None;
@@ -78,6 +84,12 @@ pub fn extract_entities(
                 }
                 "method.decorator" => {
                     decorator = Some(node_text(node, source));
+                }
+                "func.params" | "method.params" => {
+                    params_capture = Some(node_text(node, source));
+                }
+                "func.return_type" | "method.return_type" => {
+                    return_type_capture = Some(node_text(node, source));
                 }
                 "class.name" => {
                     name_text = Some(node_text(node, source));
@@ -210,9 +222,12 @@ pub fn extract_entities(
                 _ => 1,
             };
 
-            let parameters = extract_child_text(node, "parameters", source);
-            let return_type = extract_child_text(node, "return_type", source)
-                .or_else(|| extract_child_text(node, "result", source));
+            let parameters =
+                params_capture.or_else(|| extract_child_text(node, "parameters", source));
+            let return_type = return_type_capture.or_else(|| {
+                extract_child_text(node, "return_type", source)
+                    .or_else(|| extract_child_text(node, "result", source))
+            });
 
             let visibility = extract_visibility(node, source);
 
@@ -834,6 +849,74 @@ mod tests {
             symbols[0].return_type.is_none(),
             "no return type annotation"
         );
+    }
+
+    #[test]
+    fn test_kotlin_function_extracts_parameters_and_return_type() {
+        // tree-sitter-kotlin-ng's function_declaration has no named
+        // "parameters"/"return_type" fields at all -- function_value_parameters
+        // and the return type are both positional children. Verified against
+        // the crate's real node-types.json before writing this test.
+        let grammar = tree_sitter_kotlin_ng::LANGUAGE.into();
+        let src = b"fun greet(name: String, age: Int): String {\n    return name\n}\n";
+        let mut parser = Parser::new();
+        parser.set_language(&grammar).unwrap();
+        let tree = parser.parse(src, None).unwrap();
+        let root = tree.root_node();
+
+        let query = tree_sitter::Query::new(
+            &grammar,
+            "(function_declaration\n  \
+               name: (identifier) @func.name\n  \
+               (function_value_parameters) @func.params\n  \
+               (type)? @func.return_type) @func.def",
+        )
+        .unwrap();
+
+        let symbols = extract_entities("greet.kt", src, root, &query, "kotlin");
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "greet");
+        assert!(
+            symbols[0].parameters.is_some(),
+            "parameters should be extracted via the @func.params capture"
+        );
+        assert!(
+            symbols[0].parameters.as_deref().unwrap().contains("name"),
+            "parameters should contain param names: {:?}",
+            symbols[0].parameters
+        );
+        assert_eq!(
+            symbols[0].return_type.as_deref(),
+            Some("String"),
+            "return_type should be extracted via the @func.return_type capture"
+        );
+    }
+
+    #[test]
+    fn test_kotlin_function_without_return_type_annotation() {
+        // @func.return_type is an optional capture (`(type)?`) -- must not
+        // panic or produce a bogus value when a function has no explicit
+        // return type (Kotlin infers Unit).
+        let grammar = tree_sitter_kotlin_ng::LANGUAGE.into();
+        let src = b"fun sayHi(name: String) {\n    println(name)\n}\n";
+        let mut parser = Parser::new();
+        parser.set_language(&grammar).unwrap();
+        let tree = parser.parse(src, None).unwrap();
+        let root = tree.root_node();
+
+        let query = tree_sitter::Query::new(
+            &grammar,
+            "(function_declaration\n  \
+               name: (identifier) @func.name\n  \
+               (function_value_parameters) @func.params\n  \
+               (type)? @func.return_type) @func.def",
+        )
+        .unwrap();
+
+        let symbols = extract_entities("sayHi.kt", src, root, &query, "kotlin");
+        assert_eq!(symbols.len(), 1);
+        assert!(symbols[0].parameters.is_some());
+        assert_eq!(symbols[0].return_type, None);
     }
 
     #[test]

--- a/crates/infigraph-languages/languages/dart/entities.scm
+++ b/crates/infigraph-languages/languages/dart/entities.scm
@@ -17,14 +17,31 @@
   name: (identifier) @class.name) @class.def
 
 ; Top-level function declarations
+; function_signature genuinely has "parameters"/"return_type" named
+; fields, but they're one level below @func.def (reached via
+; function_declaration's own "signature" field) -- capture them
+; directly here rather than relying on child_by_field_name on the
+; outer node, which can't see through that extra level.
+; Field order below must match the grammar's actual child order
+; (return_type, name, parameters) -- tree-sitter's query matcher is
+; order-sensitive across sibling field patterns even when each is
+; field-qualified, so declaring them out of order silently fails to
+; match the return_type capture.
 (function_declaration
   signature: (function_signature
-    name: (identifier) @func.name)) @func.def
+    return_type: (type)? @func.return_type
+    name: (identifier) @func.name
+    parameters: (formal_parameter_list) @func.params)) @func.def
 
 ; Method signatures
+; method_signature has ZERO named fields of its own -- there is no
+; child_by_field_name path to "parameters" here at any nesting depth,
+; so this capture is required, not just an optimization.
 (method_signature
   (function_signature
-    name: (identifier) @method.name)) @method.def
+    return_type: (type)? @method.return_type
+    name: (identifier) @method.name
+    parameters: (formal_parameter_list) @method.params)) @method.def
 
 ; Constructor signatures
 (constructor_signature

--- a/crates/infigraph-languages/languages/kotlin/entities.scm
+++ b/crates/infigraph-languages/languages/kotlin/entities.scm
@@ -1,8 +1,13 @@
 ; Kotlin entity extraction queries (tree-sitter-kotlin-ng grammar)
 
 ; Function declarations
+; function_value_parameters and the return type are positional children
+; on this grammar, not named fields -- extract_child_text can't reach
+; either via child_by_field_name, so capture them explicitly here.
 (function_declaration
-  name: (identifier) @func.name) @func.def
+  name: (identifier) @func.name
+  (function_value_parameters) @func.params
+  (type)? @func.return_type) @func.def
 
 ; Class declarations
 (class_declaration


### PR DESCRIPTION
## Summary

`Symbol.parameters`/`return_type` are populated at tree-sitter extraction time via `extract_child_text(node, "parameters"/"return_type", source)`, which calls `child_by_field_name`. This works correctly for 11 of 14 languages this project's SCIP indexers cover, but is structurally broken for Kotlin and Dart — verified against each grammar's actual `node-types.json`, not assumed:

- **Kotlin**: `tree-sitter-kotlin-ng`'s `function_declaration` node has no `parameters`/`return_type` named fields at all — the parameter list (`function_value_parameters`) and return type (a bare `type` node) are both positional/unnamed children, structurally unreachable via `child_by_field_name` regardless of what field name is tried.
- **Dart**: two distinct issues. Plain functions' `parameters`/`return_type` live one level down on a nested `function_signature` node (reached via `function_declaration`'s `signature:` field), not on the captured node directly. Methods are worse — `method_signature` has zero named fields at all, so `parameters` is unreachable there for any method. Constructors already work correctly (`constructor_signature` has direct `name`+`parameters` fields) and are unaffected.

## Fix

Extended `extract_entities`'s existing capture-name-keyed extraction idiom (already used for `docstring`/`decorator`/`route.*` fields in `crates/infigraph-core/src/extract/entities.rs`) with two new optional capture names: `@func.params`/`@method.params` and `@func.return_type`/`@method.return_type`. When a language's `.scm` query provides these, they're preferred over the existing `child_by_field_name` fallback; when a language doesn't provide them (the other 11+ languages), the fallback is used exactly as before — zero behavior change for anything already working.

Wired up for Kotlin and Dart via their own `.scm` files (`crates/infigraph-languages/languages/{kotlin,dart}/entities.scm`) — no Rust code specific to either grammar, and no changes to any other language.

One non-obvious gotcha hit and fixed during Dart's implementation: tree-sitter's query matcher is field-order-sensitive across sibling field-qualified patterns in a single query — it matches in the same relative order the fields are written in the query text. Dart's actual grammar (`function_signature`) declares `return_type` *before* `name`/`parameters` syntactically; declaring the query in the more intuitive `name → parameters → return_type` order silently drops the `return_type` capture with zero error output. The landed `.scm` uses `return_type → name → parameters`, matching the grammar's real order, with an explicit comment explaining why — verified directly against `tree-sitter-dart` 0.2.0's `grammar.js`.

## Test plan

- [x] `cargo test -p infigraph-core --lib extract::entities` — 44/44 pass (34 pre-existing + 2 new Kotlin + 3 new Dart, incl. a constructor regression guard)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p infigraph-core --all-targets -- -D warnings` — clean
- [x] Verified end-to-end against real indexed Kotlin and Dart samples via a locally-built CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)