### PR TITLE
fix: infigraph watch releases its lock file on SIGTERM, not just Ctrl-C

### DIFF
--- a/crates/infigraph-cli/Cargo.toml
+++ b/crates/infigraph-cli/Cargo.toml
@@ -54,7 +54,7 @@ serde.workspace = true
 serde_json.workspace = true
 clap = { version = "4", features = ["derive", "env"] }
 dirs = "5"
-ctrlc = "3"
+ctrlc = { version = "3", features = ["termination"] }
 rayon = "1"
 ureq = "2"
 sha2 = "0.10"


### PR DESCRIPTION
## Summary

`ctrlc::set_handler` (used in `cmd_watch`, `crates/infigraph-cli/src/info_commands.rs`) only catches **SIGINT** by default on Unix — SIGTERM (and SIGHUP) require the crate's `termination` feature. Without it, stopping `infigraph watch` via `kill`/`pkill`/any process-manager-style shutdown (not just interactive Ctrl-C) bypasses the existing graceful `stop_rx`-based shutdown path entirely: the OS kills the process directly, no Rust destructors run, and `watch.lock` is left holding stale acquisition content instead of being released.

Found via a real incident: a long-running watcher on a project needed to be killed and left its lock file dirty, which would have blocked a subsequent `infigraph watch` invocation from acquiring the lock (or at minimum left misleading stale state) until the file was manually cleared.

## Fix

One-line dependency change — enable the `ctrlc` crate's `termination` feature so the *same* `set_handler` closure (already correctly wired to the existing graceful-shutdown `stop_rx` channel) also fires on SIGTERM/SIGHUP, not just SIGINT.

## Test plan

- [x] Manually verified: before this change, `kill -TERM` on a running `infigraph watch` process terminates it immediately with no "Watch stopped." message and a stale `watch.lock`.
- [x] After this change, `kill -TERM` prints `"Watch stopped."` (the existing graceful shutdown path) and clears `watch.lock`, matching Ctrl-C behavior exactly.
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p infigraph-cli --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)