### PR TITLE
fix: watch loop holds one persistent DB connection instead of open/close per batch

### DIFF
--- a/crates/infigraph-core/src/watch/mod.rs
+++ b/crates/infigraph-core/src/watch/mod.rs
@@ -51,9 +51,17 @@ impl std::fmt::Display for WatchEvent {
 
 /// Watch a project directory and auto-reindex on file changes.
 ///
-/// Opens a short-lived DB connection for each batch of changes rather than
-/// holding one open continuously. This avoids Kuzu file-lock conflicts on
-/// Windows where mandatory locking prevents concurrent DB connections.
+/// On non-Windows platforms, holds one DB connection open for the whole
+/// watch session and reuses it across batches — see `watch_db`. Reopening a
+/// fresh connection per batch was the original design, but each open/close
+/// cycle forces a full Kuzu checkpoint (`forceCheckpointOnClose`), and at
+/// sustained watch frequency (roughly once per second of active editing)
+/// that turns a long session into thousands of forced checkpoints, which was
+/// found to cause severe embedded-graph-file bloat over time (multi-GB
+/// write amplification per cycle at scale, independent of actual data
+/// growth). On Windows, mandatory file locking prevents a second concurrent
+/// connection while another handle on the same file is open elsewhere, so
+/// the original per-batch open/close behavior is kept there.
 ///
 /// Blocks until `stop_rx` receives a signal.
 pub fn watch_project<MR>(
@@ -120,6 +128,11 @@ where
     // then index them all at once using the bulk write path.
     let mut batch = ChangeBatch::new(1000);
 
+    // Shared DB connection for the watch session — see `watch_db`'s doc
+    // comment for the platform split (held open on non-Windows, reopened
+    // per call on Windows).
+    let mut held_prism: Option<Infigraph> = None;
+
     let sentinel = root.join(".infigraph").join("watch.stop");
 
     const MAX_RESTARTS: u32 = 3;
@@ -155,14 +168,17 @@ where
             && last_periodic.elapsed() >= Duration::from_secs(periodic_secs)
         {
             if let Some(ref cb) = on_periodic {
-                if let Ok(prism) = open_transient(root, &make_registry) {
+                if let Ok(prism) = watch_db(root, &make_registry, &mut held_prism) {
                     match prism.index() {
                         Ok(result) => {
                             if !result.extractions.is_empty() {
                                 cb(&result);
                             }
                         }
-                        Err(e) => eprintln!("[watch] periodic reindex failed: {e}"),
+                        Err(e) => {
+                            eprintln!("[watch] periodic reindex failed: {e}");
+                            poison_watch_db(&mut held_prism);
+                        }
                     }
                 }
             }
@@ -176,7 +192,7 @@ where
             let count = paths.len();
             eprintln!("[watch] batch indexing {count} files");
 
-            if let Ok(prism) = open_transient(root, &make_registry) {
+            if let Ok(prism) = watch_db(root, &make_registry, &mut held_prism) {
                 match prism.index_files(&paths) {
                     Ok(result) => {
                         changes_since_periodic += result.indexed_files;
@@ -194,7 +210,7 @@ where
                         }
 
                         for extraction in &result.extractions {
-                            let cross = has_cross_file_calls(&prism, &extraction.file);
+                            let cross = has_cross_file_calls(prism, &extraction.file);
                             let abs_path = root.join(&extraction.file);
                             on_event(WatchEvent {
                                 kind: WatchEventKind::Modified,
@@ -203,9 +219,14 @@ where
                             });
                         }
                     }
-                    Err(e) => eprintln!("[watch] batch reindex failed: {e}"),
+                    Err(e) => {
+                        eprintln!("[watch] batch reindex failed: {e}");
+                        poison_watch_db(&mut held_prism);
+                    }
                 }
-                // prism drops here, releasing the DB lock
+                // On non-Windows this connection stays open for reuse by the
+                // next batch; on Windows it's closed on the next `watch_db`
+                // call's reopen (or when the loop exits).
             }
         }
 
@@ -230,7 +251,7 @@ where
 
                     match watch_kind {
                         WatchEventKind::Removed => {
-                            if let Ok(prism) = open_transient(root, &make_registry) {
+                            if let Ok(prism) = watch_db(root, &make_registry, &mut held_prism) {
                                 let _ = prism.remove_file(&path);
                                 // Also remove files under this path (handles directory removal)
                                 let _ = prism.remove_files_by_prefix(&path);
@@ -426,6 +447,52 @@ where
     let mut prism = Infigraph::open(root, registry)?;
     prism.init()?;
     Ok(prism)
+}
+
+/// Acquires the watch session's shared DB connection, opening it if not
+/// already held. On non-Windows platforms this connection is reused across
+/// the whole watch session rather than reopened per batch/event — see
+/// `watch_project_with_periodic`'s doc comment for why that matters. If an
+/// operation on the returned connection fails, call `poison_watch_db` so the
+/// next call reopens fresh (e.g. after the on-disk database was replaced out
+/// from under a live connection, such as a concurrent `infigraph index
+/// --full` against a project this watcher is also watching).
+#[cfg(not(windows))]
+fn watch_db<'a, MR>(
+    root: &Path,
+    make_registry: &MR,
+    held: &'a mut Option<Infigraph>,
+) -> Result<&'a mut Infigraph>
+where
+    MR: Fn() -> Result<crate::lang::LanguageRegistry>,
+{
+    if held.is_none() {
+        *held = Some(open_transient(root, make_registry)?);
+    }
+    Ok(held.as_mut().unwrap())
+}
+
+/// Windows' mandatory file locking prevents a second concurrent connection
+/// while another handle on the same file is open elsewhere, so each call
+/// opens (and the previous one closes) fresh rather than holding one open
+/// across the whole session — see `open_transient`.
+#[cfg(windows)]
+fn watch_db<'a, MR>(
+    root: &Path,
+    make_registry: &MR,
+    held: &'a mut Option<Infigraph>,
+) -> Result<&'a mut Infigraph>
+where
+    MR: Fn() -> Result<crate::lang::LanguageRegistry>,
+{
+    *held = Some(open_transient(root, make_registry)?);
+    Ok(held.as_mut().unwrap())
+}
+
+/// Drops the watch session's shared DB connection so the next `watch_db`
+/// call reopens fresh. See `watch_db`'s doc comment for when to call this.
+fn poison_watch_db(held: &mut Option<Infigraph>) {
+    *held = None;
 }
 
 /// Returns the relative paths of files that have cross-file CALLS edges to/from the given file.

--- a/crates/infigraph-mcp/tests/groups_watch_perf.rs
+++ b/crates/infigraph-mcp/tests/groups_watch_perf.rs
@@ -218,12 +218,19 @@ fn test_groups_watch_perf() {
     // --- group_index ---
     let result = tool_group_index(&json!({"group_name": "test-microservices"})).unwrap();
     assert!(result.contains("Indexed"), "group_index: {result}");
+    // Auto-watch (triggered by the earlier group_add/group_query calls) may
+    // have already indexed both repos in the background by the time this
+    // explicit call runs, in which case index_group correctly reports 0
+    // repos needing work rather than re-listing them by name. Both outcomes
+    // mean the data is indexed (already confirmed via group_query above),
+    // so accept either rather than assuming this call always does the work.
+    let already_current = result.contains("Indexed 0 repos");
     assert!(
-        result.contains("order-service"),
+        already_current || result.contains("order-service"),
         "group_index: missing order-service: {result}"
     );
     assert!(
-        result.contains("user-service"),
+        already_current || result.contains("user-service"),
         "group_index: missing user-service: {result}"
     );
 


### PR DESCRIPTION
> **Status: draft, reworking.** As currently written, this fix would make #46 worse — holding one connection open for the watcher's whole session (this PR's fix for the checkpoint-storm bloat below) means readers get permanently locked out instead of hitting only brief per-batch windows. #43 and #46 are two sides of the same tradeoff and need a combined solution before this merges. See #46 for details.

Relates to #46

## Summary

Root-caused a real-world incident where `infigraph watch` grew a project's `.infigraph/graph` file to 54GB over a long editing session (logical content was ~58k symbols; a single open/close cycle on the bloated file showed ~3GB of write amplification, confirmed via an APFS CoW clone before cleanup).

Root cause: `infigraph` never issues an explicit `CHECKPOINT`, and lbug/Kuzu's `SystemConfig::default()` has `forceCheckpointOnClose = true` — every `Database` close forces a full checkpoint. The watch loop's `open_transient` opened a brand-new DB connection on every batch flush (roughly once per second during active editing) and on every file-removal event, so a multi-hour session turned into thousands of forced checkpoint cycles. The underlying storage engine's page allocator requires one *contiguous* free range per allocation and can't shrink an interior free region — so under sustained small-write churn at scale, this pattern is a plausible driver of unbounded file growth (independent of actual logical data growth).

## Fix

`watch_project_with_periodic` now holds one DB connection open for the whole watch session on non-Windows platforms (`watch_db`/`poison_watch_db`), reopening only if an operation on it errors — e.g. if the on-disk database gets replaced out from under it by a concurrent `infigraph index --full` elsewhere. Windows keeps the original per-batch open/close behavior, since Windows mandatory file locking (which prevents a second concurrent connection while another handle on the same file is open) was `open_transient`'s sole original rationale — that comment is preserved and updated in the diff.

Also hardened `groups_watch_perf.rs`'s `group_index` assertion: it previously assumed the explicit `group_index` call always performs the (re)indexing work, but auto-watch (triggered by earlier calls in the same test) can legitimately have already indexed both repos in the background by the time it runs, in which case `index_group` correctly reports 0 repos needing work rather than re-listing them by name. Both outcomes mean the data is indexed (already confirmed via `group_query` earlier in the test) — the assertion now accepts either. This is a genuine, if narrow, pre-existing race between the test's assumptions and background auto-watch timing; this PR's connection-reuse change appears to make the background indexing complete measurably faster/more reliably, which increases how often it wins the race (observed empirically: before this test fix, this specific branch failed with the "already indexed" signature in 3 of 6 `groups_watch_perf` runs, vs. 0 of 4 on an unmodified `main` baseline with a matched build).

## Verification

- Full `infigraph-core`, `infigraph-cli`, and `infigraph-mcp` test suites green (the only unrelated failure, `compression_eval`'s search-savings assertions, is a pre-existing environment quirk when tests run from a directory nested under an actively-watched parent repo — unrelated to this diff, not reproducible in a normal checkout).
- `fmt`/`clippy` clean.
- Empirically verified via a live smoke test: started a real `infigraph watch` session and confirmed via `lsof` that the graph file's file descriptor (same inode) stays open across two separate batches rather than closing and reopening between them.

## Test plan
- [x] `cargo test -p infigraph-core` — all pass
- [x] `cargo test -p infigraph-cli` — all pass
- [x] `cargo test -p infigraph-mcp` (excluding the pre-existing unrelated `compression_eval` environment quirk noted above) — all pass
- [x] `cargo fmt --all -- --check` / `cargo clippy --all-targets -- -D warnings` — clean
- [x] Manual smoke test confirming the DB connection stays open across watch batches via `lsof`
