### PR TITLE
fix: SCIP enrichment duplicate-PK crash, COPY bad-record retry, ENOSPC preflight

### DIFF
--- a/crates/infigraph-core/src/graph/store.rs
+++ b/crates/infigraph-core/src/graph/store.rs
@@ -58,6 +58,17 @@ impl GraphStore {
         Ok(store)
     }
 
+    /// Directory containing the graph database files. Used for disk-space
+    /// preflight checks before a large write (see `store_util::check_disk_headroom`)
+    /// -- Kuzu aborts the whole process with an uncaught C++ exception on
+    /// ENOSPC mid-transaction rather than surfacing a Rust `Result`, so
+    /// callers doing a large bulk write must check headroom themselves
+    /// first (observed on sittir: SCIP enrichment ran the volume out of
+    /// space mid-COPY and crashed the process).
+    pub fn db_dir(&self) -> Option<&Path> {
+        self.lock_path.parent()
+    }
+
     /// Open an existing Kuzu database in read-only mode.
     /// Safe for concurrent access while a watcher is writing.
     pub fn open_read_only(path: &Path) -> Result<Self> {

--- a/crates/infigraph-core/src/graph/store_parquet.rs
+++ b/crates/infigraph-core/src/graph/store_parquet.rs
@@ -8,7 +8,9 @@ use kuzu::Connection;
 
 use super::parquet_loader;
 use super::store::GraphStore;
-use super::store_util::{escape, fwd_slash_path, unwind_edges_from_pairs};
+use super::store_util::{
+    copy_edges_with_bad_record_retry, escape, fwd_slash_path, unwind_edges_from_pairs,
+};
 use crate::model::{FileExtraction, RelationKind};
 
 fn unique_tmp_dir() -> std::path::PathBuf {
@@ -528,17 +530,14 @@ impl GraphStore {
                 continue;
             }
             let edge_pq = tmp.join(format!("infigraph_index_{}.parquet", table.to_lowercase()));
-            let refs: Vec<(&str, &str)> = pairs
-                .iter()
-                .map(|(a, b)| (a.as_str(), b.as_str()))
-                .collect();
-            parquet_loader::write_edge_parquet(&edge_pq, &refs)?;
-            if let Err(e) = conn.query(&format!("COPY {table} FROM '{}'", fwd_slash_path(&edge_pq)))
-            {
-                eprintln!("warn: COPY {table} via parquet failed ({e}), falling back to UNWIND");
-                unwind_edges_from_pairs(conn, &refs, table, src_label, dst_label);
-            }
-            let _ = std::fs::remove_file(&edge_pq);
+            copy_edges_with_bad_record_retry(
+                conn,
+                table,
+                pairs.to_vec(),
+                src_label,
+                dst_label,
+                &edge_pq,
+            );
         }
 
         // Custom edge tables
@@ -551,23 +550,14 @@ impl GraphStore {
                 "infigraph_index_{}.parquet",
                 edge_name.to_lowercase()
             ));
-            let refs: Vec<(&str, &str)> = pairs
-                .iter()
-                .map(|(a, b)| (a.as_str(), b.as_str()))
-                .collect();
-            parquet_loader::write_edge_parquet(&edge_pq, &refs)?;
-            if let Err(e) = conn.query(&format!(
-                "COPY {} FROM '{}'",
+            copy_edges_with_bad_record_retry(
+                conn,
                 edge_name,
-                fwd_slash_path(&edge_pq)
-            )) {
-                eprintln!(
-                    "warn: COPY {} via parquet failed ({e}), falling back to UNWIND",
-                    edge_name
-                );
-                unwind_edges_from_pairs(conn, &refs, edge_name, "Symbol", "Symbol");
-            }
-            let _ = std::fs::remove_file(&edge_pq);
+                pairs.to_vec(),
+                "Symbol",
+                "Symbol",
+                &edge_pq,
+            );
         }
 
         // Cleanup node parquet files

--- a/crates/infigraph-core/src/graph/store_util.rs
+++ b/crates/infigraph-core/src/graph/store_util.rs
@@ -1,4 +1,52 @@
+use std::path::Path;
+
 use kuzu::Connection;
+
+use crate::graph::parquet_loader;
+
+/// How many bad-record-drop-and-retry cycles a bulk COPY gets before giving
+/// up and falling back to the slow per-row UNWIND path for whatever remains.
+/// Bounded so a batch with many genuinely-bad rows still terminates instead
+/// of looping indefinitely.
+const MAX_BAD_RECORD_RETRIES: usize = 20;
+
+/// Absolute floor of free space required before attempting any bulk write,
+/// regardless of the projected write size -- Kuzu needs headroom for WAL and
+/// temp buffers even for a small COPY.
+const MIN_DISK_HEADROOM_BYTES: u64 = 200 * 1024 * 1024;
+
+/// How many bytes of free space to require per byte of projected write size
+/// (source data read, or an existing on-disk estimate). Conservative
+/// multiplier for WAL/temp-buffer write amplification, not a precise model.
+const DISK_HEADROOM_FACTOR: u64 = 3;
+
+/// Check that the volume holding `dir` has enough free space to safely
+/// attempt a write of roughly `projected_write_bytes`. Returns `Err` with a
+/// human-readable shortfall description if not -- callers should abort the
+/// write entirely rather than let Kuzu run out of disk mid-transaction,
+/// which crashes the whole process with an uncaught C++ exception instead of
+/// surfacing a `Result` (observed on sittir: SCIP enrichment's COPY ran the
+/// volume out of space and crashed with `TransactionManagerException`).
+///
+/// If free space can't be determined (e.g. `dir` doesn't exist, or the
+/// platform call fails), the check passes -- an unrelated I/O error here
+/// shouldn't block a write; let the write itself surface any real problem.
+pub(crate) fn check_disk_headroom(dir: &Path, projected_write_bytes: u64) -> Result<(), String> {
+    let needed = projected_write_bytes
+        .saturating_mul(DISK_HEADROOM_FACTOR)
+        .max(MIN_DISK_HEADROOM_BYTES);
+    match fs2::available_space(dir) {
+        Ok(avail) if avail >= needed => Ok(()),
+        Ok(avail) => Err(format!(
+            "only {} MB free on the volume holding {}, need ~{} MB headroom for a ~{} MB write",
+            avail / (1024 * 1024),
+            dir.display(),
+            needed / (1024 * 1024),
+            projected_write_bytes / (1024 * 1024),
+        )),
+        Err(_) => Ok(()),
+    }
+}
 
 /// Escape single quotes and control characters for Kuzu string literals.
 pub(crate) fn escape(s: &str) -> String {
@@ -33,6 +81,87 @@ pub(crate) fn unwind_edges_from_pairs(
             pair_list.join(", ")
         ));
     }
+}
+
+/// Extract the offending value from a Kuzu COPY-failure error message, if it
+/// looks like a bad-primary-key error recoverable by dropping just that
+/// record and retrying -- a duplicate id within the batch (or one that
+/// already exists in the graph), or an edge endpoint id that doesn't match
+/// any existing row. Returns `None` for errors that don't name a specific
+/// value, so callers know to fall back rather than retry blindly.
+pub(crate) fn extract_bad_copy_value(err: &str) -> Option<&str> {
+    for marker in [
+        "duplicated primary key value ",
+        "Unable to find primary key value ",
+    ] {
+        if let Some(idx) = err.find(marker) {
+            let rest = &err[idx + marker.len()..];
+            let end = rest.find(", which").unwrap_or(rest.len());
+            let val = rest[..end].trim_end_matches('.').trim();
+            if !val.is_empty() {
+                return Some(val);
+            }
+        }
+    }
+    None
+}
+
+/// Bulk-COPY an edge table from `pairs`, retrying with the offending
+/// endpoint's pairs dropped whenever the failure is a recoverable
+/// bad-primary-key error (a duplicate edge, or an endpoint id that doesn't
+/// exist in `src_label`/`dst_label`). Falls back to per-row UNWIND only once
+/// retries are exhausted (`MAX_BAD_RECORD_RETRIES`) or the error isn't
+/// recognized as recoverable -- avoids paying the slow UNWIND path for an
+/// entire batch over a handful of bad rows.
+pub(crate) fn copy_edges_with_bad_record_retry(
+    conn: &Connection,
+    table: &str,
+    mut pairs: Vec<(String, String)>,
+    src_label: &str,
+    dst_label: &str,
+    edge_pq: &Path,
+) {
+    for attempt in 0..MAX_BAD_RECORD_RETRIES {
+        if pairs.is_empty() {
+            return;
+        }
+        let refs: Vec<(&str, &str)> = pairs
+            .iter()
+            .map(|(a, b)| (a.as_str(), b.as_str()))
+            .collect();
+        if parquet_loader::write_edge_parquet(edge_pq, &refs).is_err() {
+            break;
+        }
+        match conn.query(&format!("COPY {table} FROM '{}'", fwd_slash_path(edge_pq))) {
+            Ok(_) => {
+                let _ = std::fs::remove_file(edge_pq);
+                return;
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                if let Some(bad) = extract_bad_copy_value(&msg) {
+                    let before = pairs.len();
+                    pairs.retain(|(a, b)| a != bad && b != bad);
+                    if pairs.len() < before {
+                        eprintln!(
+                            "warn: COPY {table} dropped {} bad-PK record(s) (attempt {}/{MAX_BAD_RECORD_RETRIES}), retrying",
+                            before - pairs.len(),
+                            attempt + 1
+                        );
+                        continue;
+                    }
+                }
+                eprintln!("warn: COPY {table} via parquet failed ({e}), falling back to UNWIND");
+                break;
+            }
+        }
+    }
+    let refs: Vec<(&str, &str)> = pairs
+        .iter()
+        .map(|(a, b)| (a.as_str(), b.as_str()))
+        .collect();
+    unwind_edges_from_pairs(conn, &refs, table, src_label, dst_label);
+    let _ = std::fs::remove_file(edge_pq);
 }
 
 pub fn classify_file(file: &str) -> &'static str {
@@ -83,7 +212,53 @@ pub fn classify_file(file: &str) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::classify_file;
+    use super::{check_disk_headroom, classify_file, extract_bad_copy_value};
+
+    #[test]
+    fn disk_headroom_passes_for_tiny_projected_write_on_real_dir() {
+        // Real syscall against a real directory -- any dev/CI machine has
+        // far more than 200MB free on the temp volume, and a 1-byte
+        // projected write floors to the minimum headroom, not scaled up.
+        assert!(check_disk_headroom(&std::env::temp_dir(), 1).is_ok());
+    }
+
+    #[test]
+    fn disk_headroom_does_not_block_on_unreadable_path() {
+        // Can't determine free space for a path that doesn't exist -- must
+        // not block the write over an unrelated lookup failure.
+        let bogus = std::path::Path::new("/does/not/exist/anywhere/infigraph-test");
+        assert!(check_disk_headroom(bogus, 1024 * 1024 * 1024 * 1024).is_ok());
+    }
+
+    #[test]
+    fn extracts_duplicated_primary_key_value() {
+        // Real Kuzu COPY-failure text observed on sittir's SCIP enrichment.
+        let err = "Found duplicated primary key value packages/codegen/src/compiler/link.ts::\"'\"0, which violates the uniqueness constraint of the primary key column.";
+        assert_eq!(
+            extract_bad_copy_value(err),
+            Some("packages/codegen/src/compiler/link.ts::\"'\"0")
+        );
+    }
+
+    #[test]
+    fn extracts_unable_to_find_primary_key_value() {
+        let err = "Unable to find primary key value packages/codegen/src/compiler/collect-slots.ts::scip-typescript npm @sittir/codegen 0.1.0 src/compiler/`collect-slots.ts`/findNestedSeparator().(rule).";
+        assert_eq!(
+            extract_bad_copy_value(err),
+            Some(
+                "packages/codegen/src/compiler/collect-slots.ts::scip-typescript npm @sittir/codegen 0.1.0 src/compiler/`collect-slots.ts`/findNestedSeparator().(rule)"
+            )
+        );
+    }
+
+    #[test]
+    fn returns_none_for_unrecognized_errors() {
+        assert_eq!(
+            extract_bad_copy_value("Invalid transaction type to rollback."),
+            None
+        );
+        assert_eq!(extract_bad_copy_value("No space left on device"), None);
+    }
 
     #[test]
     fn impl_files() {

--- a/crates/infigraph-core/src/resolve/calls.rs
+++ b/crates/infigraph-core/src/resolve/calls.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use rayon::prelude::*;
 
 use crate::graph::store::GraphStore;
+use crate::graph::store_util::copy_edges_with_bad_record_retry;
 use crate::learned::LearnedStore;
 use crate::model::{FileExtraction, RelationKind};
 
@@ -355,31 +356,12 @@ fn resolve_with_map(
             })
             .collect();
 
-        let refs: Vec<(&str, &str)> = valid_pairs
-            .iter()
-            .map(|(a, b)| (a.as_str(), b.as_str()))
+        let pairs: Vec<(String, String)> = valid_pairs
+            .into_iter()
+            .map(|(a, b)| (a.clone(), b.clone()))
             .collect();
         let pq_path = std::env::temp_dir().join("infigraph_resolve_calls.parquet");
-        crate::graph::parquet_loader::write_edge_parquet(&pq_path, &refs)?;
-        let copy_result = conn.query(&format!(
-            "COPY CALLS FROM '{}'",
-            pq_path.to_string_lossy().replace('\\', "/")
-        ));
-        if let Err(e) = copy_result {
-            eprintln!("[resolve] COPY FROM parquet failed ({e}), falling back to UNWIND");
-            const CHUNK_SIZE: usize = 500;
-            for chunk in refs.chunks(CHUNK_SIZE) {
-                let pair_list: Vec<String> = chunk
-                    .iter()
-                    .map(|(a, b)| format!("{{a: '{}', b: '{}'}}", escape(a), escape(b)))
-                    .collect();
-                let _ = conn.query(&format!(
-                    "UNWIND [{}] AS p MATCH (a:Symbol), (b:Symbol) WHERE a.id = p.a AND b.id = p.b CREATE (a)-[:CALLS]->(b)",
-                    pair_list.join(", ")
-                ));
-            }
-        }
-        let _ = std::fs::remove_file(&pq_path);
+        copy_edges_with_bad_record_retry(conn, "CALLS", pairs, "Symbol", "Symbol", &pq_path);
     }
 
     Ok(ResolveStats {

--- a/crates/infigraph-core/src/resolve/inherits.rs
+++ b/crates/infigraph-core/src/resolve/inherits.rs
@@ -2,9 +2,10 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 
+use crate::graph::store_util::copy_edges_with_bad_record_retry;
 use crate::model::{FileExtraction, RelationKind};
 
-use super::{escape, shortest_id};
+use super::shortest_id;
 
 const TYPE_KINDS: &[&str] = &["Class", "Interface", "Struct", "Trait", "Enum"];
 
@@ -155,31 +156,12 @@ pub(crate) fn resolve_inherits(
         return Ok(0);
     }
 
-    let refs: Vec<(&str, &str)> = valid_pairs
-        .iter()
-        .map(|(a, b)| (a.as_str(), b.as_str()))
+    let pairs: Vec<(String, String)> = valid_pairs
+        .into_iter()
+        .map(|(a, b)| (a.clone(), b.clone()))
         .collect();
     let pq_path = std::env::temp_dir().join("infigraph_resolve_inherits.parquet");
-    crate::graph::parquet_loader::write_edge_parquet(&pq_path, &refs)?;
-    let copy_result = conn.query(&format!(
-        "COPY INHERITS FROM '{}'",
-        pq_path.to_string_lossy().replace('\\', "/")
-    ));
-    if let Err(e) = copy_result {
-        eprintln!("[resolve] COPY INHERITS FROM parquet failed ({e}), falling back to UNWIND");
-        const CHUNK_SIZE: usize = 500;
-        for chunk in refs.chunks(CHUNK_SIZE) {
-            let pair_list: Vec<String> = chunk
-                .iter()
-                .map(|(a, b)| format!("{{a: '{}', b: '{}'}}", escape(a), escape(b)))
-                .collect();
-            let _ = conn.query(&format!(
-                "UNWIND [{}] AS p MATCH (a:Symbol), (b:Symbol) WHERE a.id = p.a AND b.id = p.b CREATE (a)-[:INHERITS]->(b)",
-                pair_list.join(", ")
-            ));
-        }
-    }
-    let _ = std::fs::remove_file(&pq_path);
+    copy_edges_with_bad_record_retry(conn, "INHERITS", pairs, "Symbol", "Symbol", &pq_path);
 
     Ok(count)
 }

--- a/crates/infigraph-core/src/scip/mod.rs
+++ b/crates/infigraph-core/src/scip/mod.rs
@@ -9,7 +9,9 @@ use protobuf::Message;
 use scip::types::{symbol_information, Index, SymbolRole};
 
 use crate::graph::parquet_loader;
-use crate::graph::store_util::{escape, fwd_slash_path, unwind_edges_from_pairs};
+use crate::graph::store_util::{
+    copy_edges_with_bad_record_retry, escape, extract_bad_copy_value, fwd_slash_path,
+};
 use crate::graph::GraphStore;
 use crate::model::{Span, SymbolKind};
 
@@ -32,6 +34,17 @@ pub fn import_scip_index(
     let mut stats = ImportStats::default();
     let _lock = store.write_lock()?;
     let conn = store.connection()?;
+
+    // Preflight disk headroom before any COPY/UNWIND write. Kuzu aborts the
+    // whole process with an uncaught C++ exception on ENOSPC mid-transaction
+    // rather than surfacing a Result -- this crashed sittir's SCIP import.
+    if let Some(dir) = store.db_dir() {
+        if let Err(shortfall) =
+            crate::graph::store_util::check_disk_headroom(dir, bytes.len() as u64)
+        {
+            anyhow::bail!("Auto-SCIP: refusing to import -- {shortfall}");
+        }
+    }
 
     // Load learned pattern store for recording SCIP corrections
     let mut learned_store = project_root
@@ -175,93 +188,127 @@ pub fn import_scip_index(
         stats.files_processed += 1;
     }
 
-    // Bulk insert new SCIP symbols via Parquet COPY FROM
+    // Bulk insert new SCIP symbols via Parquet COPY FROM. A batch containing
+    // two rows with the same id (e.g. two distinct SCIP symbols that
+    // collapse to the same extracted name) is dropped down to one entry up
+    // front -- an objectively-bad duplicate should never be sent to COPY at
+    // all. On a COPY failure against an id that already exists in the graph,
+    // drop that one record and retry rather than falling back to UNWIND for
+    // the whole batch; only exhausting MAX_SYMBOL_RETRIES falls back.
     const CHUNK: usize = 2000;
+    const MAX_SYMBOL_RETRIES: usize = 20;
     if !new_symbols.is_empty() {
         let tmp = std::env::temp_dir();
         let sym_pq = tmp.join("infigraph_scip_symbols.parquet");
 
-        let ids: Vec<&str> = new_symbols.iter().map(|(id, ..)| id.as_str()).collect();
-        let names: Vec<&str> = new_symbols
-            .iter()
-            .map(|(_, name, ..)| name.as_str())
+        let mut seen_ids = std::collections::HashSet::with_capacity(new_symbols.len());
+        let mut remaining: Vec<_> = new_symbols
+            .into_iter()
+            .filter(|(id, ..)| seen_ids.insert(id.clone()))
             .collect();
-        let kinds: Vec<&str> = new_symbols
-            .iter()
-            .map(|(_, _, kind, ..)| kind.as_str())
-            .collect();
-        let files: Vec<&str> = new_symbols
-            .iter()
-            .map(|(_, _, _, file, ..)| file.as_str())
-            .collect();
-        let start_lines: Vec<i64> = new_symbols
-            .iter()
-            .map(|(_, _, _, _, sl, ..)| *sl as i64)
-            .collect();
-        let end_lines: Vec<i64> = new_symbols.iter().map(|(.., el, _)| *el as i64).collect();
-        let docs: Vec<&str> = new_symbols.iter().map(|(.., doc)| doc.as_str()).collect();
-        let n = new_symbols.len();
-        let empty_str: Vec<&str> = vec![""; n];
-        let scip_lang: Vec<&str> = vec!["scip"; n];
-        let pub_vis: Vec<&str> = vec!["public"; n];
-        let zeros: Vec<i64> = vec![0; n];
 
-        let empty_str2: Vec<&str> = vec![""; n];
-        let pq_ok = parquet_loader::write_node_parquet(
-            &sym_pq,
-            &[
-                ("id", DataType::Utf8),
-                ("name", DataType::Utf8),
-                ("kind", DataType::Utf8),
-                ("file", DataType::Utf8),
-                ("start_line", DataType::Int64),
-                ("end_line", DataType::Int64),
-                ("signature_hash", DataType::Utf8),
-                ("language", DataType::Utf8),
-                ("visibility", DataType::Utf8),
-                ("parent", DataType::Utf8),
-                ("docstring", DataType::Utf8),
-                ("complexity", DataType::Int64),
-                ("parameters", DataType::Utf8),
-                ("return_type", DataType::Utf8),
-            ],
-            vec![
-                Arc::new(StringArray::from(ids)),
-                Arc::new(StringArray::from(names)),
-                Arc::new(StringArray::from(kinds)),
-                Arc::new(StringArray::from(files)),
-                Arc::new(Int64Array::from(start_lines)),
-                Arc::new(Int64Array::from(end_lines)),
-                Arc::new(StringArray::from(empty_str.clone())),
-                Arc::new(StringArray::from(scip_lang)),
-                Arc::new(StringArray::from(pub_vis)),
-                Arc::new(StringArray::from(empty_str)),
-                Arc::new(StringArray::from(docs)),
-                Arc::new(Int64Array::from(zeros)),
-                Arc::new(StringArray::from(empty_str2.clone())),
-                Arc::new(StringArray::from(empty_str2)),
-            ],
-        )
-        .is_ok();
+        for attempt in 0..MAX_SYMBOL_RETRIES {
+            if remaining.is_empty() {
+                break;
+            }
 
-        let copy_ok = if pq_ok {
+            let ids: Vec<&str> = remaining.iter().map(|(id, ..)| id.as_str()).collect();
+            let names: Vec<&str> = remaining
+                .iter()
+                .map(|(_, name, ..)| name.as_str())
+                .collect();
+            let kinds: Vec<&str> = remaining
+                .iter()
+                .map(|(_, _, kind, ..)| kind.as_str())
+                .collect();
+            let files: Vec<&str> = remaining
+                .iter()
+                .map(|(_, _, _, file, ..)| file.as_str())
+                .collect();
+            let start_lines: Vec<i64> = remaining
+                .iter()
+                .map(|(_, _, _, _, sl, ..)| *sl as i64)
+                .collect();
+            let end_lines: Vec<i64> = remaining.iter().map(|(.., el, _)| *el as i64).collect();
+            let docs: Vec<&str> = remaining.iter().map(|(.., doc)| doc.as_str()).collect();
+            let n = remaining.len();
+            let empty_str: Vec<&str> = vec![""; n];
+            let scip_lang: Vec<&str> = vec!["scip"; n];
+            let pub_vis: Vec<&str> = vec!["public"; n];
+            let zeros: Vec<i64> = vec![0; n];
+            let empty_str2: Vec<&str> = vec![""; n];
+
+            let pq_ok = parquet_loader::write_node_parquet(
+                &sym_pq,
+                &[
+                    ("id", DataType::Utf8),
+                    ("name", DataType::Utf8),
+                    ("kind", DataType::Utf8),
+                    ("file", DataType::Utf8),
+                    ("start_line", DataType::Int64),
+                    ("end_line", DataType::Int64),
+                    ("signature_hash", DataType::Utf8),
+                    ("language", DataType::Utf8),
+                    ("visibility", DataType::Utf8),
+                    ("parent", DataType::Utf8),
+                    ("docstring", DataType::Utf8),
+                    ("complexity", DataType::Int64),
+                    ("parameters", DataType::Utf8),
+                    ("return_type", DataType::Utf8),
+                ],
+                vec![
+                    Arc::new(StringArray::from(ids)),
+                    Arc::new(StringArray::from(names)),
+                    Arc::new(StringArray::from(kinds)),
+                    Arc::new(StringArray::from(files)),
+                    Arc::new(Int64Array::from(start_lines)),
+                    Arc::new(Int64Array::from(end_lines)),
+                    Arc::new(StringArray::from(empty_str.clone())),
+                    Arc::new(StringArray::from(scip_lang)),
+                    Arc::new(StringArray::from(pub_vis)),
+                    Arc::new(StringArray::from(empty_str)),
+                    Arc::new(StringArray::from(docs)),
+                    Arc::new(Int64Array::from(zeros)),
+                    Arc::new(StringArray::from(empty_str2.clone())),
+                    Arc::new(StringArray::from(empty_str2)),
+                ],
+            )
+            .is_ok();
+
+            if !pq_ok {
+                eprintln!("Auto-SCIP: parquet write failed, falling back to UNWIND");
+                break;
+            }
+
             match conn.query(&format!(
                 "COPY Symbol (id, name, kind, file, start_line, end_line, signature_hash, language, visibility, parent, docstring, complexity, parameters, return_type) FROM '{}'",
                 fwd_slash_path(&sym_pq)
             )) {
-                Ok(_) => true,
+                Ok(_) => {
+                    remaining.clear();
+                    break;
+                }
                 Err(e) => {
+                    let msg = e.to_string();
+                    if let Some(bad) = extract_bad_copy_value(&msg) {
+                        let before = remaining.len();
+                        remaining.retain(|(id, ..)| id != bad);
+                        if remaining.len() < before {
+                            eprintln!(
+                                "Auto-SCIP: COPY Symbol dropped bad-PK record (attempt {}/{MAX_SYMBOL_RETRIES}), retrying",
+                                attempt + 1
+                            );
+                            continue;
+                        }
+                    }
                     eprintln!("Auto-SCIP: COPY Symbol failed ({e}), falling back to UNWIND");
-                    false
+                    break;
                 }
             }
-        } else {
-            eprintln!("Auto-SCIP: parquet write failed, falling back to UNWIND");
-            false
-        };
+        }
 
-        if !copy_ok {
-            for chunk in new_symbols.chunks(CHUNK) {
+        if !remaining.is_empty() {
+            for chunk in remaining.chunks(CHUNK) {
                 let rows: Vec<String> = chunk
                     .iter()
                     .map(|(id, name, kind, file, start, end, doc)| {
@@ -386,24 +433,20 @@ pub fn import_scip_index(
         }
     }
 
-    // Bulk write CALLS edges via Parquet COPY FROM
+    // Bulk write CALLS edges via Parquet COPY FROM, dropping any bad-PK
+    // record and retrying rather than falling back to UNWIND for the batch.
     if !calls_to_create.is_empty() {
         let tmp = std::env::temp_dir();
         let edge_pq = tmp.join("infigraph_scip_calls.parquet");
-        let refs: Vec<(&str, &str)> = calls_to_create
-            .iter()
-            .map(|(a, b)| (a.as_str(), b.as_str()))
-            .collect();
-        if parquet_loader::write_edge_parquet(&edge_pq, &refs).is_ok() {
-            if let Err(e) = conn.query(&format!("COPY CALLS FROM '{}'", fwd_slash_path(&edge_pq))) {
-                eprintln!("Auto-SCIP: COPY CALLS failed ({e}), falling back to UNWIND");
-                unwind_edges_from_pairs(&conn, &refs, "CALLS", "Symbol", "Symbol");
-            }
-        } else {
-            unwind_edges_from_pairs(&conn, &refs, "CALLS", "Symbol", "Symbol");
-        }
         stats.references_added = calls_to_create.len();
-        let _ = std::fs::remove_file(&edge_pq);
+        copy_edges_with_bad_record_retry(
+            &conn,
+            "CALLS",
+            calls_to_create,
+            "Symbol",
+            "Symbol",
+            &edge_pq,
+        );
     }
 
     // Pass 3: build INHERITS edges from SCIP's compiler-verified is_implementation
@@ -458,27 +501,20 @@ pub fn import_scip_index(
         }
     }
 
-    // Bulk write INHERITS edges via Parquet COPY FROM
+    // Bulk write INHERITS edges via Parquet COPY FROM, dropping any bad-PK
+    // record and retrying rather than falling back to UNWIND for the batch.
     if !inherits_to_create.is_empty() {
         let tmp = std::env::temp_dir();
         let edge_pq = tmp.join("infigraph_scip_inherits.parquet");
-        let refs: Vec<(&str, &str)> = inherits_to_create
-            .iter()
-            .map(|(a, b)| (a.as_str(), b.as_str()))
-            .collect();
-        if parquet_loader::write_edge_parquet(&edge_pq, &refs).is_ok() {
-            if let Err(e) = conn.query(&format!(
-                "COPY INHERITS FROM '{}'",
-                fwd_slash_path(&edge_pq)
-            )) {
-                eprintln!("Auto-SCIP: COPY INHERITS failed ({e}), falling back to UNWIND");
-                unwind_edges_from_pairs(&conn, &refs, "INHERITS", "Symbol", "Symbol");
-            }
-        } else {
-            unwind_edges_from_pairs(&conn, &refs, "INHERITS", "Symbol", "Symbol");
-        }
         stats.relations_added = inherits_to_create.len();
-        let _ = std::fs::remove_file(&edge_pq);
+        copy_edges_with_bad_record_retry(
+            &conn,
+            "INHERITS",
+            inherits_to_create,
+            "Symbol",
+            "Symbol",
+            &edge_pq,
+        );
     }
 
     // Persist learned corrections (if any were recorded)
@@ -508,14 +544,90 @@ fn parse_range(range: &[i32], file: &str) -> Span {
     }
 }
 
+/// Extract the display name of the last descriptor in a SCIP symbol string.
+///
+/// SCIP symbols end with a chain of `<name><suffix>` descriptors (suffix is one
+/// of `.` term, `#` type, `/` namespace, `:` macro, or `(...)`.` method with an
+/// optional disambiguator) and the suffix is the literal last character, e.g.
+/// `rust-analyzer cargo sittir-core 0.0.0 is_allowed_node_key().` or `.../crate/`.
+/// The suffix must be stripped *before* looking for the name, otherwise it reads
+/// as trailing empty text.
+///
+/// Non-identifier names (file paths, string-literal object keys, etc.) are
+/// quoted by the indexer -- backticks for file-path descriptors, double quotes
+/// for term names that aren't valid bare identifiers -- and may carry a
+/// trailing disambiguator digit run the indexer appends to distinguish
+/// repeated non-identifier names in the same scope (e.g. `"'"0`, `` `x`1 ``).
+/// A method/term descriptor may also chain a non-empty `(...)` disambiguator
+/// group after its own (usually empty) parens, e.g. `findNestedSeparator().(rule).`.
+/// Both kinds of disambiguator are folded back into the returned name rather
+/// than dropped: dropping either collapses distinct symbols onto one name,
+/// causing a primary-key collision on insert (observed on sittir -- both a
+/// duplicate-symbol-insert failure and, separately, a dangling-edge-endpoint
+/// failure whose "name" had silently fallen back to the raw, unparsed symbol
+/// string once the old single-`if` parens handling failed to find any
+/// identifier left to extract).
 fn scip_sym_to_name(scip_sym: &str) -> String {
-    scip_sym
-        .rsplit_once('`')
-        .map(|(_, n)| n)
-        .or_else(|| scip_sym.rsplit(['#', '.', '/']).next())
-        .unwrap_or(scip_sym)
-        .trim_matches(|c| c == '(' || c == ')' || c == '`')
-        .to_string()
+    let mut s = scip_sym.trim_end();
+
+    // Strip a trailing method terminator.
+    if let Some(rest) = s.strip_suffix('.') {
+        s = rest;
+    }
+
+    // Strip trailing `(...)` disambiguator groups, possibly chained. An
+    // empty group (the common case for a plain method call) carries no
+    // information and is dropped; a non-empty one is preserved by appending
+    // it to the extracted name below.
+    let mut suffix = String::new();
+    while s.ends_with(')') {
+        let Some(open) = s.rfind('(') else { break };
+        let inner = &s[open + 1..s.len() - 1];
+        if !inner.is_empty() {
+            suffix = format!(".{inner}{suffix}");
+        }
+        s = s[..open].trim_end_matches(['#', '/', ':', '.']);
+    }
+
+    // Strip a single trailing suffix marker (type/namespace/macro/term).
+    let mut s = s.trim_end_matches(['#', '/', ':', '.']);
+
+    // Peel off a trailing disambiguator digit run that immediately follows a
+    // closing quote, keeping it to append to the extracted name below.
+    let mut disambiguator = "";
+    let digit_start = s
+        .rfind(|c: char| !c.is_ascii_digit())
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    if digit_start > 0 && digit_start < s.len() {
+        let quote = s.as_bytes()[digit_start - 1];
+        if quote == b'`' || quote == b'"' {
+            disambiguator = &s[digit_start..];
+            s = &s[..digit_start];
+        }
+    }
+
+    // Quoted descriptor name: `Name` or "Name" (with disambiguators re-attached).
+    for quote in ['`', '"'] {
+        if let Some(rest) = s.strip_suffix(quote) {
+            if let Some(start) = rest.rfind(quote) {
+                return format!("{}{disambiguator}{suffix}", &rest[start + 1..]);
+            }
+        }
+    }
+
+    // Bare identifier: trailing run of alphanumeric/underscore characters.
+    let ident_start = s
+        .rfind(|c: char| !(c.is_alphanumeric() || c == '_'))
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    if ident_start < s.len() {
+        format!("{}{disambiguator}{suffix}", &s[ident_start..])
+    } else if !suffix.is_empty() {
+        suffix.trim_start_matches('.').to_string()
+    } else {
+        scip_sym.to_string()
+    }
 }
 
 fn scip_kind_to_prism(kind: &symbol_information::Kind) -> SymbolKind {
@@ -552,11 +664,93 @@ mod tests {
     use super::*;
     use scip::types::{Document, Occurrence, Relationship, SymbolInformation};
 
-    // Bare names (no scheme/package/descriptor-suffix structure) so these tests
-    // exercise only the is_implementation -> INHERITS mapping, independent of
-    // scip_sym_to_name's descriptor parsing.
-    fn scip_symbol(name: &str, _file: &str) -> String {
-        name.to_string()
+    #[test]
+    fn scip_sym_to_name_strips_trailing_suffix_markers() {
+        // Real rust-analyzer output: suffix char is the literal last byte.
+        assert_eq!(
+            scip_sym_to_name("rust-analyzer cargo sittir-core 0.0.0 crate/"),
+            "crate"
+        );
+        assert_eq!(
+            scip_sym_to_name("rust-analyzer cargo sittir-core 0.0.0 K_IDENTIFIER."),
+            "K_IDENTIFIER"
+        );
+        assert_eq!(
+            scip_sym_to_name("rust-analyzer cargo sittir-core 0.0.0 is_allowed_node_key()."),
+            "is_allowed_node_key"
+        );
+        assert_eq!(
+            scip_sym_to_name("rust-analyzer cargo sittir-core 0.0.0 SomeTrait#method()."),
+            "method"
+        );
+    }
+
+    #[test]
+    fn scip_sym_to_name_handles_chained_disambiguator_group() {
+        // Real scip-typescript output that crashed sittir's SCIP import: a
+        // method descriptor's empty `()` chained with a further non-empty
+        // `(rule)` disambiguator. The old single-`if` parens handling
+        // stripped only the last group, left a dangling `()` with nothing
+        // extractable after it, and fell back to returning the entire raw,
+        // unparsed symbol string as the "name" -- which then couldn't match
+        // any real Symbol id, causing a dangling-edge COPY failure.
+        assert_eq!(
+            scip_sym_to_name(
+                "scip-typescript npm @sittir/codegen 0.1.0 src/compiler/`collect-slots.ts`/findNestedSeparator().(rule)."
+            ),
+            "findNestedSeparator.rule"
+        );
+    }
+
+    #[test]
+    fn scip_sym_to_name_empty_disambiguator_group_still_strips_cleanly() {
+        // A plain method call's empty `()` must still resolve to the bare
+        // method name, unaffected by the loop that now also handles
+        // non-empty chained groups.
+        assert_eq!(
+            scip_sym_to_name("rust-analyzer cargo sittir-core 0.0.0 is_allowed_node_key()."),
+            "is_allowed_node_key"
+        );
+    }
+
+    #[test]
+    fn scip_sym_to_name_handles_backtick_quoted_descriptors() {
+        // Real scip-typescript output: file-path descriptors are backtick-quoted.
+        assert_eq!(
+            scip_sym_to_name("scip-typescript npm test 1.0.0 `test.ts`/Animal#"),
+            "Animal"
+        );
+        assert_eq!(
+            scip_sym_to_name("scip-python python test-pkg 1.0.0 `test`/Animal#"),
+            "Animal"
+        );
+    }
+
+    #[test]
+    fn scip_sym_to_name_handles_double_quoted_descriptors_with_disambiguator() {
+        // Real scip-typescript output for a non-identifier term name (e.g. an
+        // object property literally named `'`): the quoted name is followed
+        // by a disambiguator digit, then the term suffix `.`.
+        assert_eq!(
+            scip_sym_to_name("scip-typescript npm @sittir/codegen 0.1.0 `link.ts`/\"'\"0."),
+            "'0"
+        );
+    }
+
+    #[test]
+    fn scip_sym_to_name_disambiguator_keeps_repeated_quoted_names_distinct() {
+        // Two different quoted-name symbols in the same scope that share a
+        // disambiguator digit must not collapse onto the same extracted name
+        // -- doing so caused a primary-key collision on sittir's graph.
+        let a = scip_sym_to_name("scip-typescript npm test 1.0.0 \"'\"0.");
+        let b = scip_sym_to_name("scip-typescript npm test 1.0.0 \",\"0.");
+        assert_ne!(a, b);
+        assert_eq!(a, "'0");
+        assert_eq!(b, ",0");
+    }
+
+    fn scip_symbol(name: &str, file: &str) -> String {
+        format!("scip-test npm test 1.0.0 `{file}`/{name}#")
     }
 
     fn make_scip_index(file: &str, child: &str, parent: &str) -> Vec<u8> {

--- a/crates/infigraph-mcp/tests/groups_watch_perf.rs
+++ b/crates/infigraph-mcp/tests/groups_watch_perf.rs
@@ -218,12 +218,19 @@ fn test_groups_watch_perf() {
     // --- group_index ---
     let result = tool_group_index(&json!({"group_name": "test-microservices"})).unwrap();
     assert!(result.contains("Indexed"), "group_index: {result}");
+    // Auto-watch (triggered by the earlier group_add/group_query calls) may
+    // have already indexed both repos in the background by the time this
+    // explicit call runs, in which case index_group correctly reports 0
+    // repos needing work rather than re-listing them by name. Both outcomes
+    // mean the data is indexed (already confirmed via group_query above),
+    // so accept either rather than assuming this call always does the work.
+    let already_current = result.contains("Indexed 0 repos");
     assert!(
-        result.contains("order-service"),
+        already_current || result.contains("order-service"),
         "group_index: missing order-service: {result}"
     );
     assert!(
-        result.contains("user-service"),
+        already_current || result.contains("user-service"),
         "group_index: missing user-service: {result}"
     );
 


### PR DESCRIPTION
## Summary

Root-causes a crash observed in a real-world SCIP-enrichment run: `scip_sym_to_name` had two bugs that produced colliding or garbled symbol names, which crashed the bulk `COPY` insert with a primary-key collision.

- **`scip_sym_to_name`** (`crates/infigraph-core/src/scip/mod.rs`) didn't handle:
  - a double-quote-quoted descriptor with a trailing disambiguator digit (e.g. `` "'"0 ``, used by scip-typescript for non-identifier term names like string-literal object keys)
  - a chained non-empty `(...)` disambiguator group after a method's own empty parens (e.g. `` findNestedSeparator().(rule). ``), which fell through to returning the raw, unparsed SCIP symbol string as the "name"

  Both now fold the disambiguator into the returned name instead of discarding it — dropping it collapsed genuinely distinct symbols onto the same extracted name, causing the primary-key collision that crashed the `COPY`.

- **Bad-record-drop-and-retry heuristic.** Replaced the "`COPY` fails → fall back to slow per-row `UNWIND` for the whole batch" pattern everywhere it occurs (SCIP's Symbol/CALLS/INHERITS inserts, the main indexer's edge-table loop, `resolve/calls.rs`, `resolve/inherits.rs`) with a bounded drop-bad-record-and-retry-`COPY` heuristic: parse the offending value out of Kuzu's own `COPY` error text, drop just that record, and retry the bulk `COPY` (up to 20 attempts) before falling back to `UNWIND`. Avoids paying the slow per-row path for an entire batch over a handful of bad rows.

- **Disk-headroom preflight before SCIP's bulk writes.** Kuzu throws an uncaught C++ `TransactionManagerException` on ENOSPC mid-transaction, aborting the whole process rather than surfacing a `Result`. Added a preflight check (`GraphStore::db_dir` + `store_util::check_disk_headroom`, using the already-present `fs2` dependency) that refuses gracefully with a normal error instead.

- Also hardened a pre-existing flaky assertion in `crates/infigraph-mcp/tests/groups_watch_perf.rs` (`group_index` can legitimately report "Indexed 0 repos" if background auto-watch already indexed both repos by the time the explicit call runs — both outcomes mean the data is indexed).

## Test plan

- [x] `cargo test -p infigraph-core --lib` — 284/284 passing (includes 4 new regression tests for the two `scip_sym_to_name` bugs, plus tests for the new `extract_bad_copy_value`/`check_disk_headroom` helpers)
- [x] `cargo test -p infigraph-mcp --test groups_watch_perf -- --ignored` — verified across multiple runs after the assertion fix
- [x] `cargo test -p infigraph-core --test write_lock_perf -- --ignored` — passing
- [x] `cargo test -p infigraph-core --test index_perf -- --ignored` — passing
- [x] `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjmvwHuwV5r7ZeZpJLp5oR