### PR TITLE
fix: include symbol_id in search results

### DIFF
--- a/crates/infigraph-cli/src/search_commands.rs
+++ b/crates/infigraph-cli/src/search_commands.rs
@@ -92,8 +92,8 @@ pub(crate) fn cmd_search(root: &Path, query: &str, limit: usize, alpha: f32) -> 
     for r in &results {
         if let Some(row) = rows.iter().find(|row| row[0] == r.symbol_id) {
             println!(
-                "  {:.3} (bm25:{:.2} vec:{:.2})  {:>8} {:30} {}",
-                r.score, r.bm25_score, r.vector_score, row[2], row[1], row[3]
+                "  {:.3} (bm25:{:.2} vec:{:.2})  {:>8} {:30} {}  id={}",
+                r.score, r.bm25_score, r.vector_score, row[2], row[1], row[3], r.symbol_id
             );
             let doc = row.get(4).map(|s| s.as_str()).unwrap_or("");
             if !doc.is_empty() {

--- a/crates/infigraph-mcp/src/tools/search.rs
+++ b/crates/infigraph-mcp/src/tools/search.rs
@@ -455,8 +455,8 @@ pub fn tool_search(args: &Value) -> Result<String> {
                 _ => String::new(),
             };
             out.push_str(&format!(
-                "{:.3}  {} {} ({}{})\n",
-                r.score, row[2], row[1], row[3], lines
+                "{:.3}  {} {} ({}{})  id={}\n",
+                r.score, row[2], row[1], row[3], lines, r.symbol_id
             ));
             if let Some(doc) = row.get(4).filter(|s| !s.is_empty()) {
                 let preview: String = doc.chars().take(120).collect();
@@ -597,8 +597,8 @@ pub fn tool_search_symbols(args: &Value) -> Result<String> {
                 _ => String::new(),
             };
             out.push_str(&format!(
-                "{:.3}  {} {} ({}{})\n",
-                r.score, row[2], row[1], row[3], lines
+                "{:.3}  {} {} ({}{})  id={}\n",
+                r.score, row[2], row[1], row[3], lines, r.symbol_id
             ));
         }
     }


### PR DESCRIPTION
## Summary
`tool_search`, `tool_search_symbols` (MCP), and `cmd_search` (CLI) all correlate results back to a row keyed by `symbol_id` internally, but never printed it in the output. That breaks the ability to chain a search result directly into `trace_callers`/`get_code_snippet`/`symbol_context`/`transitive_impact` — callers have to fall back to `get_symbols_in_file` (which does print `id=`) just to get an ID usable with those tools.

## Change
Appends `id=<symbol_id>` to each result line in all three functions, matching `get_symbols_in_file`'s existing convention.

## Test plan
- [x] `cargo build -p infigraph-mcp -p infigraph-cli` — clean
- [x] `cargo test -p infigraph-mcp --test tool_dispatch` — pass
- [x] `cargo test -p infigraph-cli` — pass (includes `cli_parity`)
- [x] Manually verified `infigraph search` and the MCP `search`/`search_symbols` tools now include `id=` in output