### PR TITLE
fix: CLI read-only commands grab a write-capable connection, colliding with a live watcher

### DIFF
--- a/crates/infigraph-cli/src/analysis_commands.rs
+++ b/crates/infigraph-cli/src/analysis_commands.rs
@@ -129,7 +129,7 @@ pub(crate) fn cmd_security(
 pub(crate) fn cmd_complexity(root: &Path, threshold: u32, file: Option<&str>) -> Result<()> {
     let registry = bundled_registry()?;
     let mut prism = Infigraph::open(root, registry)?;
-    prism.init()?;
+    prism.init_read_only()?;
 
     let backend = prism.backend().context("graph not initialized")?;
     let rows = backend.get_complexity_ranking(file)?;
@@ -203,7 +203,7 @@ pub(crate) fn cmd_semantic_diff(root: &Path, old_ref: &str, new_ref: &str) -> Re
 pub(crate) fn cmd_sequence(root: &Path, symbol_id: &str, depth: u32) -> Result<()> {
     let registry = bundled_registry()?;
     let mut prism = Infigraph::open(root, registry)?;
-    prism.init()?;
+    prism.init_read_only()?;
     let backend = prism.backend().context("not initialized")?;
     let diagram = infigraph_core::sequence::generate_sequence_mermaid(backend, symbol_id, depth)?;
     println!("{}", diagram);
@@ -223,7 +223,7 @@ pub(crate) fn cmd_review(
 ) -> Result<()> {
     let registry = bundled_registry()?;
     let mut prism = Infigraph::open(root, registry)?;
-    prism.init()?;
+    prism.init_read_only()?;
     let backend = prism
         .backend()
         .context("graph not initialized -- run 'infigraph index' first")?;

--- a/crates/infigraph-cli/src/graph_commands.rs
+++ b/crates/infigraph-cli/src/graph_commands.rs
@@ -7,7 +7,12 @@ use infigraph_languages::bundled_registry;
 pub(crate) fn cmd_query(root: &Path, cypher: &str) -> Result<()> {
     let registry = bundled_registry()?;
     let mut prism = Infigraph::open(root, registry)?;
-    prism.init()?;
+    // Read-only, matching the `query_graph` MCP tool: `cypher` is arbitrary
+    // user input, but rather than inspect it for write statements, this
+    // relies on the backend's own read-only enforcement to reject them
+    // clearly ("Cannot execute write operations in a read-only database")
+    // -- exactly like `query_graph` already does.
+    prism.init_read_only()?;
 
     let backend = prism.backend().context("graph not initialized")?;
     let rows = backend.raw_query(cypher)?;

--- a/crates/infigraph-cli/src/info_commands.rs
+++ b/crates/infigraph-cli/src/info_commands.rs
@@ -8,7 +8,7 @@ use serde_json::json;
 pub(crate) fn cmd_stats(root: &Path) -> Result<()> {
     let registry = bundled_registry()?;
     let mut prism = Infigraph::open(root, registry)?;
-    prism.init()?;
+    prism.init_read_only()?;
     let stats = prism.stats()?;
     println!("{}", stats);
     Ok(())
@@ -35,7 +35,7 @@ pub(crate) fn cmd_languages(project_root: Option<&Path>) -> Result<()> {
 pub(crate) fn cmd_symbols(root: &Path, file: &str) -> Result<()> {
     let registry = bundled_registry()?;
     let mut prism = Infigraph::open(root, registry)?;
-    prism.init()?;
+    prism.init_read_only()?;
 
     let backend = prism.backend().context("graph not initialized")?;
     let symbols = backend.symbols_in_file(file)?;
@@ -60,7 +60,7 @@ pub(crate) fn cmd_symbols(root: &Path, file: &str) -> Result<()> {
 pub(crate) fn cmd_skeleton(root: &Path, file: &str) -> Result<()> {
     let registry = bundled_registry()?;
     let mut prism = Infigraph::open(root, registry)?;
-    prism.init()?;
+    prism.init_read_only()?;
 
     let backend = prism.backend().context("graph not initialized")?;
     let result = backend.skeleton(file)?;
@@ -212,7 +212,7 @@ pub(crate) fn cmd_dependencies(root: &Path, ecosystem: Option<&str>) -> Result<(
 pub(crate) fn cmd_api_surface(root: &Path, file_filter: Option<&str>) -> Result<()> {
     let registry = bundled_registry()?;
     let mut prism = Infigraph::open(root, registry)?;
-    prism.init()?;
+    prism.init_read_only()?;
     let backend = prism.backend().context("graph not initialized")?;
     let mut syms = backend.get_api_surface()?;
     if let Some(f) = file_filter {
@@ -234,7 +234,7 @@ pub(crate) fn cmd_api_surface(root: &Path, file_filter: Option<&str>) -> Result<
 pub(crate) fn cmd_file_deps(root: &Path, file: &str) -> Result<()> {
     let registry = bundled_registry()?;
     let mut prism = Infigraph::open(root, registry)?;
-    prism.init()?;
+    prism.init_read_only()?;
     let backend = prism.backend().context("graph not initialized")?;
     let deps = backend.get_file_deps(file)?;
     println!("File dependencies for '{}':\n", file);
@@ -258,7 +258,7 @@ pub(crate) fn cmd_file_deps(root: &Path, file: &str) -> Result<()> {
 pub(crate) fn cmd_type_hierarchy(root: &Path, symbol: &str, depth: u32) -> Result<()> {
     let registry = bundled_registry()?;
     let mut prism = Infigraph::open(root, registry)?;
-    prism.init()?;
+    prism.init_read_only()?;
     let backend = prism.backend().context("graph not initialized")?;
     let hier = backend.get_type_hierarchy(symbol, depth)?;
     println!("Type hierarchy for '{}':\n", hier.root_name);
@@ -282,7 +282,7 @@ pub(crate) fn cmd_type_hierarchy(root: &Path, symbol: &str, depth: u32) -> Resul
 pub(crate) fn cmd_test_coverage(root: &Path, file_filter: Option<&str>) -> Result<()> {
     let registry = bundled_registry()?;
     let mut prism = Infigraph::open(root, registry)?;
-    prism.init()?;
+    prism.init_read_only()?;
     let backend = prism.backend().context("graph not initialized")?;
     let mut cov = backend.get_test_coverage()?;
     if let Some(f) = file_filter {
@@ -560,7 +560,7 @@ pub(crate) fn cmd_index_confluence(
 pub(crate) fn cmd_list_files(root: &Path, glob: Option<&str>) -> Result<()> {
     let registry = bundled_registry()?;
     let mut prism = Infigraph::open(root, registry)?;
-    prism.init()?;
+    prism.init_read_only()?;
 
     let backend = prism.backend().context("graph not initialized")?;
     let rows = backend.raw_query("MATCH (s:Symbol) RETURN DISTINCT s.file ORDER BY s.file")?;
@@ -592,7 +592,7 @@ pub(crate) fn cmd_generate_test_context(
 ) -> Result<()> {
     let registry = bundled_registry()?;
     let mut prism = Infigraph::open(root, registry)?;
-    prism.init()?;
+    prism.init_read_only()?;
 
     let backend = prism.backend().context("graph not initialized")?;
     let ctx = backend.generate_test_context(file, limit, None)?;

--- a/crates/infigraph-cli/src/search_commands.rs
+++ b/crates/infigraph-cli/src/search_commands.rs
@@ -8,7 +8,7 @@ pub(crate) fn cmd_search(root: &Path, query: &str, limit: usize, alpha: f32) -> 
 
     let registry = bundled_registry()?;
     let mut prism = Infigraph::open(root, registry)?;
-    prism.init()?;
+    prism.init_read_only()?;
 
     let backend = prism.backend().context("graph not initialized")?;
     let rows =
@@ -132,7 +132,7 @@ pub(crate) fn cmd_search_code(
 pub(crate) fn cmd_snippet(root: &Path, symbol_id: &str) -> Result<()> {
     let registry = bundled_registry()?;
     let mut prism = Infigraph::open(root, registry)?;
-    prism.init()?;
+    prism.init_read_only()?;
 
     let backend = prism.backend().context("graph not initialized")?;
     let detail = backend
@@ -158,7 +158,7 @@ pub(crate) fn cmd_snippet(root: &Path, symbol_id: &str) -> Result<()> {
 pub(crate) fn cmd_find_refs(root: &Path, symbol: &str) -> Result<()> {
     let registry = bundled_registry()?;
     let mut prism = Infigraph::open(root, registry)?;
-    prism.init()?;
+    prism.init_read_only()?;
     let backend = prism.backend().context("graph not initialized")?;
     let refs = backend.find_all_references(symbol)?;
     if refs.is_empty() {

--- a/crates/infigraph-cli/src/viz_commands.rs
+++ b/crates/infigraph-cli/src/viz_commands.rs
@@ -46,7 +46,7 @@ pub(crate) fn cmd_visualize_symbol(root: &Path, symbol_id: &str, depth: u32) -> 
 pub(crate) fn cmd_routes(root: &Path) -> Result<()> {
     let registry = bundled_registry()?;
     let mut prism = Infigraph::open(root, registry)?;
-    prism.init()?;
+    prism.init_read_only()?;
 
     let backend = prism.backend().context("graph not initialized")?;
 


### PR DESCRIPTION
Addresses the specific symptom named in #46: `infigraph query` / `get_file_deps` (and 15 other CLI commands) failing with `"graph is locked by another infigraph process"` while a watcher is running.

## Root cause

Not the deeper concurrent read/write question #46 raises (tracked separately upstream at [LadybugDB/ladybug#766](https://github.com/LadybugDB/ladybug/issues/766), found while investigating this) -- it's much simpler: 17 CLI commands whose MCP tool counterpart already correctly opens read-only (`open_prism_read_only`/`init_read_only()`) instead opened write-capable (`prism.init()`). That's an ordinary write-vs-write conflict Kuzu correctly and permanently rejects -- caused entirely by these commands unnecessarily requesting write access for what is, in every case here, a pure read.

## Fix

Converted (CLI command -> underlying connection mode, mirroring the already-correct MCP tool):
`query`, `symbols`, `stats`, `snippet`, `routes`, `find-refs`, `api-surface`, `file-deps`, `type-hierarchy`, `test-coverage`, `complexity`, `skeleton`, `files`, `test-context`, `sequence`, `review`, `search`

`query`'s cypher is arbitrary user input, but rather than inspect it for write statements, this mirrors `query_graph`'s existing MCP behavior exactly: open read-only and let the backend reject write statements with its own clear error (`"Cannot execute write operations in a read-only database"`).

`memory-context` needed no change -- it already delegates directly to `tool_memory_context`, which was already read-only.

The remaining 36 write-capable CLI call sites are unchanged: either genuinely write-oriented (`index`, `group build`/`index`, `delete`, `ingest`), or their MCP counterpart is *also* write-capable (the whole `analysis/` module -- `dead-code`, `callers`, `callees`, `impact`, `taint`, `security`, `clones`, etc. -- none of which use `open_prism_read_only` on the MCP side either), so those aren't CLI/MCP mismatches and are out of scope here.

## Verification

- Started a real `infigraph watch`, confirmed via `watch-status` it was alive both before and after, and ran `infigraph query` against it mid-session -- succeeds cleanly now, where it previously failed with `"graph is locked by another infigraph process"`.
- `cargo test -p infigraph-cli` (69 unit tests + `cli_parity` integration tests): all pass.
- `cargo fmt -- --check` / `cargo clippy --all-targets -- -D warnings`: clean.

## Relation to #43

Independent of #43 (and the reason this is a separate PR, not bundled with it) -- #43 addresses the deeper "watcher holds one connection open for its whole session" design tradeoff, which per the discussion on #46 needs a combined solution with #46 before merging. This PR fixes a much narrower, unrelated bug: commands that never needed write access in the first place. It can land independently of how #43/#46 get resolved.

## Follow-up

This class of bug (structurally identical connection-opening logic duplicated between `infigraph-cli` and `infigraph-mcp`, free to drift out of sync) is now filed as supporting evidence on #24 (deduplicate CLI and MCP tool implementations).