### PR TITLE
fix: guard release.sh against a Cargo.toml/tag version mismatch

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -23,6 +23,18 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Guard against releasing a binary whose baked-in CARGO_PKG_VERSION doesn't
+# match the release tag. Cutting a release with a stale workspace version
+# ships a binary that reports the wrong `infigraph --version` (see #49) --
+# fail loudly here instead of silently uploading a mismatched build.
+VERSION_NUM="${VERSION#v}"
+CARGO_VERSION="$(awk -F'"' '/^\[workspace\.package\]/{f=1} f && /^version[[:space:]]*=/{print $2; exit}' Cargo.toml)"
+if [ "$CARGO_VERSION" != "$VERSION_NUM" ]; then
+  echo "error: release tag is ${VERSION} (${VERSION_NUM}) but Cargo.toml [workspace.package] version is ${CARGO_VERSION}."
+  echo "Bump the workspace version in Cargo.toml to ${VERSION_NUM} and commit it before releasing."
+  exit 1
+fi
+
 # Detect current platform
 OS="$(uname -s)"
 


### PR DESCRIPTION
Fixes #49

## Root cause

`release.sh` takes a version tag as its only argument but never checks it against `Cargo.toml`'s `[workspace.package] version` before building. `clap` derives `--version` from `CARGO_PKG_VERSION` at compile time (`crates/infigraph-cli/src/main.rs:49`), so a release cut without first bumping `Cargo.toml` ships a binary whose `--version` output silently lags the release tag it was built for.

Confirmed via `git log -p -- Cargo.toml`: the last version bump before the reported bug was `3.2.5 → 3.2.6`. No commit ever bumped it to `3.2.7` or `3.2.8` — the next bump on record is `3.2.9`. So both v3.2.7 and v3.2.8 were built and tagged with the stale `3.2.6` baked in, which also explains why v3.2.6 and v3.2.8 share an identical `aarch64-apple-darwin` binary hash (no version-relevant recompile happened between them on that platform).

## Fix

Add a check right after argument parsing in `release.sh`: extract the workspace version from `Cargo.toml` and fail loudly if it doesn't match the requested release tag (`$VERSION`), before any build/upload work happens.

```
$ ./release.sh v3.2.8   # Cargo.toml still says 3.2.6
error: release tag is v3.2.8 (3.2.8) but Cargo.toml [workspace.package] version is 3.2.6.
Bump the workspace version in Cargo.toml to 3.2.8 and commit it before releasing.
```

## Testing

`release.sh` isn't part of the `cargo test` suite (it's an ops script), so I verified it directly:
- `bash -n release.sh` — syntax check passes
- Ran the version-extraction + comparison logic standalone against the real `Cargo.toml` (currently `3.2.9`) — matches correctly, and correctly rejects a mismatched tag
- Reproduced the historical bug scenario (`Cargo.toml=3.2.6`, tag=`v3.2.8`) — the guard fires with the exact error above, confirming it would have caught #49 before either broken release shipped

I didn't attempt to auto-bump `Cargo.toml` from the script — that's a bigger behavior change (deciding whether the script should also commit a version bump) that seemed worth a separate discussion; this PR just stops the bad release from happening silently.
