### PR TITLE
perf(docs): persist the doc-search BM25 index across sessions

### DIFF
--- a/crates/infigraph-docs/src/search.rs
+++ b/crates/infigraph-docs/src/search.rs
@@ -217,6 +217,43 @@ pub fn hybrid_doc_search(
     hybrid_doc_search_in_dir(query, store, &root.join(".infigraph"), limit, alpha)
 }
 
+/// Cache is usable iff both files exist and the cache is at least as new as
+/// the embeddings sidecar — the same freshness anchor code search uses for
+/// bm25_cache.bin. Doc reindex rewrites docs_embeddings.bin, so a reindex
+/// automatically invalidates the cache.
+fn doc_bm25_cache_fresh(cache_path: &Path, anchor_path: &Path) -> bool {
+    let (Ok(cache_meta), Ok(anchor_meta)) = (
+        std::fs::metadata(cache_path),
+        std::fs::metadata(anchor_path),
+    ) else {
+        return false;
+    };
+    match (cache_meta.modified(), anchor_meta.modified()) {
+        (Ok(c), Ok(a)) => c >= a,
+        _ => false,
+    }
+}
+
+fn load_or_build_doc_index(
+    store: &dyn DocBackend,
+    cache_path: &Path,
+    anchor_path: &Path,
+) -> Result<(Vec<(String, String)>, DocBM25Index)> {
+    if doc_bm25_cache_fresh(cache_path, anchor_path) {
+        if let Ok(idx) = DocBM25Index::load(cache_path) {
+            return Ok((idx.docs().to_vec(), idx));
+        }
+    }
+    let chunks = store.get_all_chunks()?;
+    let idx = DocBM25Index::build(chunks.clone());
+    // Only cache when the anchor exists — without it there is no invalidation
+    // signal. Save failures are non-fatal: worst case is today's per-query rebuild.
+    if anchor_path.exists() && !chunks.is_empty() {
+        let _ = idx.save(cache_path);
+    }
+    Ok((chunks, idx))
+}
+
 pub fn hybrid_doc_search_in_dir(
     query: &str,
     store: &dyn DocBackend,
@@ -224,13 +261,14 @@ pub fn hybrid_doc_search_in_dir(
     limit: usize,
     alpha: f32,
 ) -> Result<Vec<DocSearchResult>> {
-    let chunks = store.get_all_chunks()?;
+    let emb_path = artifact_dir.join("docs_embeddings.bin");
+    let cache_path = artifact_dir.join("docs_bm25_cache.bin");
+    let (chunks, bm25_index) = load_or_build_doc_index(store, &cache_path, &emb_path)?;
 
     if chunks.is_empty() {
         return Ok(Vec::new());
     }
 
-    let bm25_index = DocBM25Index::build(chunks.clone());
     let bm25_results = bm25_index.search(query, limit * 3);
 
     // Normalize BM25
@@ -245,7 +283,6 @@ pub fn hybrid_doc_search_in_dir(
         .collect();
 
     // Vector search
-    let emb_path = artifact_dir.join("docs_embeddings.bin");
     let hnsw_path = artifact_dir.join("docs_hnsw_index.usearch");
 
     let embedder = doc_embedder();

--- a/crates/infigraph-docs/src/search.rs
+++ b/crates/infigraph-docs/src/search.rs
@@ -159,13 +159,7 @@ impl DocBM25Index {
             Ok(v)
         };
         let read_str = |data: &[u8], pos: &mut usize| -> Result<String> {
-            let len = {
-                let end = pos.checked_add(4).filter(|&e| e <= data.len());
-                let end = end.ok_or_else(|| anyhow::anyhow!("truncated doc bm25 cache"))?;
-                let v = u32::from_le_bytes(data[*pos..end].try_into().unwrap()) as usize;
-                *pos = end;
-                v
-            };
+            let len = read_u32(data, pos)? as usize;
             let end = pos.checked_add(len).filter(|&e| e <= data.len());
             let end = end.ok_or_else(|| anyhow::anyhow!("truncated doc bm25 cache"))?;
             let s = String::from_utf8_lossy(&data[*pos..end]).into_owned();

--- a/crates/infigraph-docs/src/search.rs
+++ b/crates/infigraph-docs/src/search.rs
@@ -25,6 +25,9 @@ pub struct DocSearchResult {
 const K1: f32 = 1.2;
 const B: f32 = 0.75;
 
+/// On-disk format version for docs_bm25_cache.bin.
+const DOC_BM25_CACHE_VERSION: u8 = 1;
+
 pub struct DocBM25Index {
     docs: Vec<(String, String)>,
     inverted: HashMap<String, Vec<(usize, f32)>>,
@@ -91,6 +94,112 @@ impl DocBM25Index {
         results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
         results.truncate(limit);
         results
+    }
+
+    pub fn docs(&self) -> &[(String, String)] {
+        &self.docs
+    }
+
+    /// Serialize to `path` atomically (temp file + rename in the same directory).
+    /// Layout: version u8 | avg_doc_len f32 | doc_count u32 |
+    /// [id_len u32, id, text_len u32, text]* | term_count u32 |
+    /// [term_len u32, term, posting_count u32, [doc_idx u32, tf f32]*]*
+    pub fn save(&self, path: &Path) -> Result<()> {
+        let mut buf = Vec::new();
+        buf.push(DOC_BM25_CACHE_VERSION);
+        buf.extend_from_slice(&self.avg_doc_len.to_le_bytes());
+        buf.extend_from_slice(&(self.docs.len() as u32).to_le_bytes());
+        for (id, text) in &self.docs {
+            let id_b = id.as_bytes();
+            buf.extend_from_slice(&(id_b.len() as u32).to_le_bytes());
+            buf.extend_from_slice(id_b);
+            let text_b = text.as_bytes();
+            buf.extend_from_slice(&(text_b.len() as u32).to_le_bytes());
+            buf.extend_from_slice(text_b);
+        }
+        buf.extend_from_slice(&(self.inverted.len() as u32).to_le_bytes());
+        for (term, postings) in &self.inverted {
+            let tb = term.as_bytes();
+            buf.extend_from_slice(&(tb.len() as u32).to_le_bytes());
+            buf.extend_from_slice(tb);
+            buf.extend_from_slice(&(postings.len() as u32).to_le_bytes());
+            for &(doc_idx, tf) in postings {
+                buf.extend_from_slice(&(doc_idx as u32).to_le_bytes());
+                buf.extend_from_slice(&tf.to_le_bytes());
+            }
+        }
+        // Unique temp name per process so concurrent writers can't interleave.
+        let tmp = path.with_extension(format!("{}.tmp", std::process::id()));
+        std::fs::write(&tmp, &buf).map_err(|e| anyhow::anyhow!("write doc bm25 cache: {}", e))?;
+        std::fs::rename(&tmp, path).map_err(|e| anyhow::anyhow!("rename doc bm25 cache: {}", e))
+    }
+
+    /// Bounds-checked deserialization. Any structural problem is an `Err`
+    /// (never a panic): callers treat a bad cache as a miss and rebuild.
+    pub fn load(path: &Path) -> Result<Self> {
+        let data =
+            std::fs::read(path).map_err(|e| anyhow::anyhow!("read doc bm25 cache: {}", e))?;
+        anyhow::ensure!(
+            !data.is_empty() && data[0] == DOC_BM25_CACHE_VERSION,
+            "unsupported doc bm25 cache version"
+        );
+        let mut pos = 1usize;
+        let read_u32 = |data: &[u8], pos: &mut usize| -> Result<u32> {
+            let end = pos.checked_add(4).filter(|&e| e <= data.len());
+            let end = end.ok_or_else(|| anyhow::anyhow!("truncated doc bm25 cache"))?;
+            let v = u32::from_le_bytes(data[*pos..end].try_into().unwrap());
+            *pos = end;
+            Ok(v)
+        };
+        let read_f32 = |data: &[u8], pos: &mut usize| -> Result<f32> {
+            let end = pos.checked_add(4).filter(|&e| e <= data.len());
+            let end = end.ok_or_else(|| anyhow::anyhow!("truncated doc bm25 cache"))?;
+            let v = f32::from_le_bytes(data[*pos..end].try_into().unwrap());
+            *pos = end;
+            Ok(v)
+        };
+        let read_str = |data: &[u8], pos: &mut usize| -> Result<String> {
+            let len = {
+                let end = pos.checked_add(4).filter(|&e| e <= data.len());
+                let end = end.ok_or_else(|| anyhow::anyhow!("truncated doc bm25 cache"))?;
+                let v = u32::from_le_bytes(data[*pos..end].try_into().unwrap()) as usize;
+                *pos = end;
+                v
+            };
+            let end = pos.checked_add(len).filter(|&e| e <= data.len());
+            let end = end.ok_or_else(|| anyhow::anyhow!("truncated doc bm25 cache"))?;
+            let s = String::from_utf8_lossy(&data[*pos..end]).into_owned();
+            *pos = end;
+            Ok(s)
+        };
+
+        let avg_doc_len = read_f32(&data, &mut pos)?;
+        let doc_count = read_u32(&data, &mut pos)? as usize;
+        let mut docs = Vec::with_capacity(doc_count.min(1 << 20));
+        for _ in 0..doc_count {
+            let id = read_str(&data, &mut pos)?;
+            let text = read_str(&data, &mut pos)?;
+            docs.push((id, text));
+        }
+        let term_count = read_u32(&data, &mut pos)? as usize;
+        let mut inverted = HashMap::with_capacity(term_count.min(1 << 20));
+        for _ in 0..term_count {
+            let term = read_str(&data, &mut pos)?;
+            let pc = read_u32(&data, &mut pos)? as usize;
+            let mut postings = Vec::with_capacity(pc.min(1 << 20));
+            for _ in 0..pc {
+                let doc_idx = read_u32(&data, &mut pos)? as usize;
+                let tf = read_f32(&data, &mut pos)?;
+                anyhow::ensure!(doc_idx < docs.len(), "doc bm25 cache posting out of range");
+                postings.push((doc_idx, tf));
+            }
+            inverted.insert(term, postings);
+        }
+        Ok(Self {
+            docs,
+            inverted,
+            avg_doc_len,
+        })
     }
 }
 
@@ -355,4 +464,81 @@ fn hybrid_doc_search_remote(
         .collect();
 
     Ok(results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_index() -> DocBM25Index {
+        DocBM25Index::build(vec![
+            (
+                "chunk-1".to_string(),
+                "kuzu graph database embedded columnar".to_string(),
+            ),
+            (
+                "chunk-2".to_string(),
+                "hybrid bm25 vector search ranking".to_string(),
+            ),
+            (
+                "chunk-3".to_string(),
+                "watcher debounce reindex freshness".to_string(),
+            ),
+        ])
+    }
+
+    #[test]
+    fn save_load_roundtrip_preserves_docs_and_scores() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("docs_bm25_cache.bin");
+        let idx = sample_index();
+        idx.save(&path).unwrap();
+        let loaded = DocBM25Index::load(&path).unwrap();
+        assert_eq!(idx.docs(), loaded.docs());
+        assert_eq!(
+            idx.search("vector search", 10),
+            loaded.search("vector search", 10)
+        );
+        assert_eq!(idx.search("kuzu", 10), loaded.search("kuzu", 10));
+    }
+
+    #[test]
+    fn load_rejects_empty_wrong_version_and_truncated() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("docs_bm25_cache.bin");
+
+        std::fs::write(&path, b"").unwrap();
+        assert!(
+            DocBM25Index::load(&path).is_err(),
+            "empty file must be rejected"
+        );
+
+        std::fs::write(&path, [9u8, 1, 2, 3, 4, 5, 6, 7, 8]).unwrap();
+        assert!(
+            DocBM25Index::load(&path).is_err(),
+            "unknown version must be rejected"
+        );
+
+        let idx = sample_index();
+        idx.save(&path).unwrap();
+        let full = std::fs::read(&path).unwrap();
+        std::fs::write(&path, &full[..full.len() / 2]).unwrap();
+        // Must be an Err, not a panic: hybrid search falls back to rebuild on Err.
+        assert!(
+            DocBM25Index::load(&path).is_err(),
+            "truncated file must be rejected"
+        );
+    }
+
+    #[test]
+    fn save_is_atomic_leaves_no_temp_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("docs_bm25_cache.bin");
+        sample_index().save(&path).unwrap();
+        let names: Vec<String> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(names, vec!["docs_bm25_cache.bin".to_string()]);
+    }
 }

--- a/crates/infigraph-docs/tests/doc_bm25_cache.rs
+++ b/crates/infigraph-docs/tests/doc_bm25_cache.rs
@@ -1,0 +1,155 @@
+use infigraph_core::embed::{load_embeddings, save_embeddings};
+use infigraph_docs::chunk::{chunk_document, ChunkStrategy};
+use infigraph_docs::extract::{DocFormat, ExtractedDoc};
+use infigraph_docs::store::DocStore;
+
+fn index_doc(root: &std::path::Path, file: &str, text: &str) {
+    let full_path = root.join(file);
+    std::fs::create_dir_all(full_path.parent().unwrap()).unwrap();
+    std::fs::write(&full_path, text).unwrap();
+
+    let doc = ExtractedDoc {
+        file: file.to_string(),
+        title: Some(file.to_string()),
+        content_hash: format!("hash-{file}"),
+        format: DocFormat::Markdown,
+        text: text.to_string(),
+        page_count: None,
+    };
+    let chunks = chunk_document(&doc, file, &doc.content_hash, ChunkStrategy::HeadingBounded);
+    let chunk_refs: Vec<_> = chunks.iter().collect();
+
+    let db_path = root.join(".infigraph").join("docs.kuzu");
+    let store = DocStore::open(&db_path).unwrap();
+    store.upsert_all_parquet(&[&doc], &chunk_refs).unwrap();
+    drop(store);
+
+    let embeddings_path = root.join(".infigraph").join("docs_embeddings.bin");
+    let mut embeddings = if embeddings_path.exists() {
+        load_embeddings(&embeddings_path).unwrap()
+    } else {
+        Vec::new()
+    };
+    embeddings.extend(
+        chunks
+            .iter()
+            .map(|chunk| (chunk.id.clone(), vec![0.1; 384]))
+            .collect::<Vec<_>>(),
+    );
+    save_embeddings(&embeddings_path, &embeddings).unwrap();
+}
+
+fn open_store(root: &std::path::Path) -> DocStore {
+    DocStore::open(&root.join(".infigraph").join("docs.kuzu")).unwrap()
+}
+
+#[test]
+fn first_search_writes_cache_and_results_stay_identical() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    index_doc(
+        root,
+        "docs/a.md",
+        "# Alpha\nkuzu graph database embedded columnar",
+    );
+    index_doc(
+        root,
+        "docs/b.md",
+        "# Beta\nhybrid bm25 vector search ranking",
+    );
+
+    let store = open_store(root);
+    let artifact_dir = root.join(".infigraph");
+    let cache_path = artifact_dir.join("docs_bm25_cache.bin");
+
+    // alpha 0.0 = pure BM25: deterministic, independent of the embedder.
+    let first = infigraph_docs::search::hybrid_doc_search_in_dir(
+        "vector search",
+        &store,
+        &artifact_dir,
+        5,
+        0.0,
+    )
+    .unwrap();
+    assert!(!first.is_empty());
+    assert!(cache_path.exists(), "first search should write the cache");
+
+    let second = infigraph_docs::search::hybrid_doc_search_in_dir(
+        "vector search",
+        &store,
+        &artifact_dir,
+        5,
+        0.0,
+    )
+    .unwrap();
+    assert_eq!(first.len(), second.len());
+    for (a, b) in first.iter().zip(&second) {
+        assert_eq!(a.chunk_id, b.chunk_id);
+        assert!((a.score - b.score).abs() < 1e-6);
+    }
+}
+
+#[test]
+fn corrupt_cache_falls_back_and_is_rewritten() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    index_doc(
+        root,
+        "docs/a.md",
+        "# Alpha\nkuzu graph database embedded columnar",
+    );
+
+    let store = open_store(root);
+    let artifact_dir = root.join(".infigraph");
+    let cache_path = artifact_dir.join("docs_bm25_cache.bin");
+
+    infigraph_docs::search::hybrid_doc_search_in_dir("kuzu", &store, &artifact_dir, 5, 0.0)
+        .unwrap();
+    assert!(cache_path.exists());
+
+    // Corrupt it. fs::write also bumps its mtime, so it now looks "fresh" —
+    // the corrupt content is genuinely attempted, must not panic or error.
+    std::fs::write(&cache_path, b"garbage").unwrap();
+    let res =
+        infigraph_docs::search::hybrid_doc_search_in_dir("kuzu", &store, &artifact_dir, 5, 0.0)
+            .unwrap();
+    assert!(!res.is_empty(), "search must survive a corrupt cache");
+    assert!(
+        infigraph_docs::search::DocBM25Index::load(&cache_path).is_ok(),
+        "corrupt cache should have been rebuilt with valid content"
+    );
+}
+
+#[test]
+fn stale_cache_is_rebuilt_when_embeddings_are_newer() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    index_doc(
+        root,
+        "docs/a.md",
+        "# Alpha\nkuzu graph database embedded columnar",
+    );
+
+    let store = open_store(root);
+    let artifact_dir = root.join(".infigraph");
+    let cache_path = artifact_dir.join("docs_bm25_cache.bin");
+    let emb_path = artifact_dir.join("docs_embeddings.bin");
+
+    infigraph_docs::search::hybrid_doc_search_in_dir("kuzu", &store, &artifact_dir, 5, 0.0)
+        .unwrap();
+    let cache_mtime_before = std::fs::metadata(&cache_path).unwrap().modified().unwrap();
+
+    // Make the anchor newer than the cache (same technique as
+    // bm25_cache_stale_when_embeddings_newer in infigraph-cli).
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    let emb_bytes = std::fs::read(&emb_path).unwrap();
+    std::fs::write(&emb_path, &emb_bytes).unwrap();
+
+    infigraph_docs::search::hybrid_doc_search_in_dir("kuzu", &store, &artifact_dir, 5, 0.0)
+        .unwrap();
+    let cache_mtime_after = std::fs::metadata(&cache_path).unwrap().modified().unwrap();
+    assert!(
+        cache_mtime_after > cache_mtime_before,
+        "stale cache should have been rebuilt (mtime advanced)"
+    );
+}

--- a/docs/DOCUMENT-INDEXING.md
+++ b/docs/DOCUMENT-INDEXING.md
@@ -534,7 +534,7 @@ Standard Okapi BM25 implementation:
 
 ### Persistent cache
 
-BM25 index is persisted as `.infigraph/docs_bm25_cache.bin`, valid only when at least as new as `docs_embeddings.bin` (the freshness anchor — the same pattern code search uses for `bm25_cache.bin`), so a doc reindex that rewrites embeddings automatically invalidates the cache. A missing, stale, or corrupt cache is not an error: `load_or_build_doc_index` silently falls back to rebuilding the index in-memory from the store and best-effort re-saves it (save failures are non-fatal).
+BM25 index is persisted as `.infigraph/docs_bm25_cache.bin`, valid only when at least as new as `docs_embeddings.bin` (the freshness anchor — the same pattern code search uses for `bm25_cache.bin`), so a doc reindex that rewrites embeddings automatically invalidates the cache. A missing, stale, or corrupt cache is not an error: `load_or_build_doc_index` silently falls back to rebuilding the index in-memory from the store and best-effort re-saves it (save failures are non-fatal). The cache is only written when `docs_embeddings.bin` already exists and the chunk set is non-empty — without an anchor there is no invalidation signal, so no cache is written.
 
 ### Result format
 

--- a/docs/DOCUMENT-INDEXING.md
+++ b/docs/DOCUMENT-INDEXING.md
@@ -512,26 +512,29 @@ Embedding logic is in `embed.rs`.
 
 ## Search
 
-### hybrid_doc_search (`search.rs:97-201`)
+### hybrid_doc_search (`search.rs:206-218`)
 
-The primary search entry point, called from `tool_search_docs`:
+The primary search entry point, called from `tool_search_docs`. Delegates to `hybrid_doc_search_in_dir` (`search.rs:257-360`) for local mode:
 
-1. Load all chunks from store
-2. Build a fresh `DocBM25Index` in-memory (rebuilt per query — no persistent BM25 on disk)
-3. BM25 search for top `limit * 3` results
-4. Normalize BM25 scores by max score
-5. Vector search: embed query → HNSW search (or brute-force linear scan if no HNSW index)
-6. Normalize vector scores by max
-7. Combine: `score = (1 - alpha) * bm25 + alpha * vector` (default `alpha = 0.5`)
-8. Sort, truncate to `limit`, hydrate full chunk details
+1. Load or build a `DocBM25Index` (see Persistent cache below)
+2. BM25 search for top `limit * 3` results
+3. Normalize BM25 scores by max score
+4. Vector search: embed query → HNSW search (or brute-force linear scan if no HNSW index)
+5. Normalize vector scores by max
+6. Combine: `score = (1 - alpha) * bm25 + alpha * vector` (default `alpha = 0.5`)
+7. Sort, truncate to `limit`, hydrate full chunk details
 
-### DocBM25Index (`search.rs:28-94`)
+### DocBM25Index (`search.rs:31-204`)
 
 Standard Okapi BM25 implementation:
 
 - `build(docs)`: tokenizes all docs, builds inverted index `term → [(doc_idx, term_freq)]`, tracks `avg_doc_len`
 - `search(query, limit)`: IDF = `ln((N - df + 0.5) / (df + 0.5) + 1)`, standard TF normalization with K1 and B parameters
 - Tokenizer: simple whitespace splitting + lowercasing
+
+### Persistent cache
+
+BM25 index is persisted as `.infigraph/docs_bm25_cache.bin`, valid only when at least as new as `docs_embeddings.bin` (the freshness anchor — the same pattern code search uses for `bm25_cache.bin`), so a doc reindex that rewrites embeddings automatically invalidates the cache. A missing, stale, or corrupt cache is not an error: `load_or_build_doc_index` silently falls back to rebuilding the index in-memory from the store and best-effort re-saves it (save failures are non-fatal).
 
 ### Result format
 


### PR DESCRIPTION
## Summary

Doc search (`hybrid_doc_search_in_dir`) currently rebuilds its entire `DocBM25Index` in memory on every query — loading all chunks from the store and re-tokenizing the whole corpus — while code search already persists its BM25 index to `.infigraph/bm25_cache.bin`. This PR gives doc search the same treatment:

- `DocBM25Index` gains `save`/`load`/`docs()`. The on-disk format mirrors code search's `BM25Index::save` idiom (leading version byte + length-prefixed LE binary).
- `hybrid_doc_search_in_dir` loads `docs_bm25_cache.bin` when it is at least as new as `docs_embeddings.bin` — the same mtime freshness anchor code search uses, so a doc reindex invalidates the cache automatically. On a cache hit the `store.get_all_chunks()` DB read is skipped too (the cache carries the chunk texts).
- Miss/stale/corrupt cache → rebuild in memory exactly as before, then a best-effort atomic save (pid-unique temp file + rename). A cache failure can never fail or change a search — results are identical with and without the cache.

Two deliberate hardenings over the idiom being mirrored:
- `load` is fully bounds-checked and returns `Err` (never panics) on truncated/corrupt input, since a bad cache must degrade to a rebuild.
- The temp-file name is per-process unique, so concurrent searches can't race on the same temp path.

Group/combined doc stores get their own cache automatically (keyed off the store's artifact dir; combined stores publish per-generation directories, so no cross-generation staleness is possible).

## Testing

- 3 new unit tests: save/load round-trip preserves scores; empty/wrong-version/truncated inputs rejected without panic; atomic save leaves no temp file.
- 3 new integration tests against a real `DocStore`: first search writes the cache and repeat results are identical; corrupt cache falls back silently and is rewritten; stale cache (newer embeddings) is rebuilt.
- Full `infigraph-docs` suite: 93/93 passing on this branch (rebased on current `main`); `cargo fmt`/`clippy -D warnings`/`cargo check --workspace` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjmvwHuwV5r7ZeZpJLp5oR