### PR TITLE
fix: stop --mcp alone from triggering the UI keep-alive loop

### DIFF
--- a/crates/infigraph-mcp/src/main.rs
+++ b/crates/infigraph-mcp/src/main.rs
@@ -237,9 +237,7 @@ fn run() -> Result<()> {
     }
 
     let args: Vec<String> = std::env::args().collect();
-    let ui_enabled = args
-        .iter()
-        .any(|a| a == "--ui" || a.starts_with("--ui=") || a == "--mcp");
+    let ui_enabled = args.iter().any(|a| a == "--ui" || a.starts_with("--ui="));
     let port: u16 = args
         .iter()
         .find(|a| a.starts_with("--port="))

--- a/crates/infigraph-mcp/src/main.rs
+++ b/crates/infigraph-mcp/src/main.rs
@@ -227,6 +227,10 @@ fn acquire_instance_lock() -> Option<std::fs::File> {
     }
 }
 
+fn ui_enabled_from(args: &[String]) -> bool {
+    args.iter().any(|a| a == "--ui" || a.starts_with("--ui="))
+}
+
 fn run() -> Result<()> {
     let instance_lock = acquire_instance_lock();
     let is_primary = instance_lock.is_some();
@@ -237,7 +241,7 @@ fn run() -> Result<()> {
     }
 
     let args: Vec<String> = std::env::args().collect();
-    let ui_enabled = args.iter().any(|a| a == "--ui" || a.starts_with("--ui="));
+    let ui_enabled = ui_enabled_from(&args);
     let port: u16 = args
         .iter()
         .find(|a| a.starts_with("--port="))
@@ -384,4 +388,40 @@ fn handle_tools_list(id: &Value) -> Value {
 
 fn handle_tools_call(id: &Value, request: &Value) -> Value {
     infigraph_mcp::handle_tools_call(id, request)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(strs: &[&str]) -> Vec<String> {
+        strs.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn bare_mcp_flag_does_not_enable_ui() {
+        // Regression test: `--mcp` alone previously triggered the UI keep-alive
+        // loop, leaking a worker process that never exits on stdin EOF.
+        assert!(!ui_enabled_from(&args(&["--mcp"])));
+    }
+
+    #[test]
+    fn no_flags_does_not_enable_ui() {
+        assert!(!ui_enabled_from(&args(&[])));
+    }
+
+    #[test]
+    fn ui_flag_enables_ui() {
+        assert!(ui_enabled_from(&args(&["--ui"])));
+    }
+
+    #[test]
+    fn ui_flag_with_value_enables_ui() {
+        assert!(ui_enabled_from(&args(&["--ui=3000"])));
+    }
+
+    #[test]
+    fn mcp_and_ui_together_enables_ui() {
+        assert!(ui_enabled_from(&args(&["--mcp", "--ui"])));
+    }
 }


### PR DESCRIPTION
## Summary

 `infigraph-mcp` was leaking worker processes: passing `--mcp` alone incorrectly
  set `ui_enabled = true`, which puts the process into a `loop { sleep(3600s) }`
  keep-alive after stdin EOF instead of exiting. Over repeated MCP client
  restarts this accumulates orphaned worker processes.

  Root cause: `ui_enabled` was derived from
  `args.iter().any(|a| a == "--ui" || a.starts_with("--ui=") || a == "--mcp")` —
  the `|| a == "--mcp"` clause meant bare `--mcp` (no `--ui`) still enabled the
  UI keep-alive path. Fix removes that clause so `ui_enabled` only reflects an
  actual `--ui`/`--ui=` flag.

  Also extracted the check into `ui_enabled_from(args: &[String]) -> bool` so
  it's unit-testable in isolation from `run()`.

## Test plan

- [x ] `cargo test --all` passes
- [x ] `cargo clippy --all-targets` passes
- [x ] Tested manually (describe below)

```bash
./target/debug/infigraph-mcp --mcp < /dev/null &
  pid=$!
  sleep 5
  if kill -0 $pid 2>/dev/null; then
    echo "STILL RUNNING after 5s — bug present"
    kill -9 $pid
  else
    wait $pid
    echo "exited on its own, exit code: $?"
  fi
```
The above exited 0 after the update. 


## Notes

No behavior change for `--ui` / `--ui=<port>` / `--mcp --ui` combinations; only bare `--mcp` is affected.
