### PR TITLE
fix: guard release tag against workspace version mismatch

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -23,6 +23,17 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Guard: the tag must match the workspace version, or the binaries built
+# below will report a version (via clap's `version` from CARGO_PKG_VERSION)
+# that disagrees with the release tag they're uploaded under.
+CARGO_VERSION="$(grep -m1 '^version = ' Cargo.toml | sed -E 's/version = "(.*)"/\1/')"
+TAG_VERSION="${VERSION#v}"
+if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
+  echo "Error: release tag ${VERSION} does not match [workspace.package].version ${CARGO_VERSION} in Cargo.toml."
+  echo "Bump the workspace version to ${TAG_VERSION}, or run: $0 v${CARGO_VERSION}"
+  exit 1
+fi
+
 # Detect current platform
 OS="$(uname -s)"
 


### PR DESCRIPTION
## Summary

`release.sh` takes the release tag as a raw CLI arg (`./release.sh v0.10.0`) and never checks it against `[workspace.package].version` in `Cargo.toml`. `infigraph-cli` and `infigraph-mcp` both derive `--version` from clap's `version` field, which reads `CARGO_PKG_VERSION` at compile time from that same Cargo.toml.

So if the workspace version isn't bumped before running `release.sh v0.11.0` (or the tag arg has a typo), the built binaries silently report `--version` as the old/wrong value while the GitHub release and git tag say something else. There's no guard, and no way to fix it after upload short of deleting the release and re-running.

## Change

Added a check right after the version arg is parsed: strip the `v` prefix from the tag, compare it against `[workspace.package].version`, and exit with a clear message (pointing at the fix in either direction) before any build starts.

## Test plan

- [x] Manually verified the guard in isolation: `./release.sh v3.3.0` against the current `Cargo.toml` (`version = "3.2.15"`) fails with `Error: release tag v3.3.0 does not match [workspace.package].version 3.2.15 in Cargo.toml.`; `./release.sh v3.2.15` passes the guard and proceeds.
- [x] `bash -n release.sh` — syntax check passes.
- [ ] `cargo test --all` / `cargo clippy` — n/a, pure shell change, no Rust touched.

## Notes

Didn't run a full release build (needs cmake + full rust toolchain + would actually create/upload a release asset), the guard is a pure, isolated string comparison at the top of the script before the build/upload logic runs, so testing it standalone covers the actual change.

Fixes #49.