### PR TITLE
fix: guard release tag against workspace version mismatch

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -23,6 +23,17 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Guard: the tag must match the workspace version, or the binaries built
+# below will report a version (via clap's `version` from CARGO_PKG_VERSION)
+# that disagrees with the release tag they're uploaded under.
+CARGO_VERSION="$(grep -m1 '^version = ' Cargo.toml | sed -E 's/version = "(.*)"/\1/')"
+TAG_VERSION="${VERSION#v}"
+if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
+  echo "Error: release tag ${VERSION} does not match [workspace.package].version ${CARGO_VERSION} in Cargo.toml."
+  echo "Bump the workspace version to ${TAG_VERSION}, or run: $0 v${CARGO_VERSION}"
+  exit 1
+fi
+
 # Detect current platform
 OS="$(uname -s)"
 


### PR DESCRIPTION
## Summary

Fixes #49.

`release.sh` takes the release tag as an arbitrary CLI arg and never checks it against `[workspace.package].version` in `Cargo.toml`. `infigraph-cli`'s `--version` comes from clap's `version` field, which pulls `CARGO_PKG_VERSION` at compile time from that same `Cargo.toml`. So a forgotten version bump (or a typo in the tag arg) ships binaries whose `--version` output silently disagrees with the git tag/GitHub release they're uploaded under, with no way to fix it after the fact short of deleting the release — matching exactly what #49 reports (`--version` stuck on 3.2.6 across the v3.2.7 and v3.2.8 releases).

Guards by comparing the tag (v-prefix stripped) against the workspace version before any build starts, and fails with a clear message pointing at the fix in either direction.

## Test plan

- [x] `bash -n release.sh` passes (syntax)
- [x] Tested the guard logic in isolation against this repo's real `Cargo.toml` (currently `3.2.15`): a mismatched tag (`v9.9.9`) fails with the new error message and exit 1; a matching tag (`v3.2.15`) passes through cleanly
- [ ] `cargo test --all` / `cargo clippy` — not applicable, this is a shell-only change, no Rust touched

## Notes

Didn't run the full release build (requires cmake + a real GitHub release target), the change is isolated to the version-guard block before any build/upload step runs, so it can't affect build/package/upload behavior when the versions do match.