### PR TITLE
fix: refuse to open a graph with an unreplayed WAL from a dead process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2486,6 +2486,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.10.9",
+ "sysinfo",
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
@@ -3413,6 +3414,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3533,6 +3543,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.1",
+ "dispatch2",
+ "objc2",
 ]
 
 [[package]]
@@ -3540,6 +3552,37 @@ name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
 
 [[package]]
 name = "objc2-system-configuration"
@@ -5126,6 +5169,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.39.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "objc2-open-directory",
+ "windows",
+]
+
+[[package]]
 name = "taffy"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6512,6 +6570,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6522,6 +6601,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -6551,6 +6641,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -6661,6 +6761,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/crates/infigraph-core/Cargo.toml
+++ b/crates/infigraph-core/Cargo.toml
@@ -40,6 +40,10 @@ ignore = "0.4"
 serde_yaml = "0.9.34"
 fs2 = "0.4.3"
 memmap2 = "0.9"
+# Only used to check whether a graph write lock's recorded PID is still
+# alive (see GraphStore::unclean_shutdown_wal_holder) -- a stale WAL from a
+# dead process can crash Kuzu's WAL-replay-on-open with SIGBUS.
+sysinfo = "0.39.6"
 
 [features]
 default = []

--- a/crates/infigraph-core/src/graph/store.rs
+++ b/crates/infigraph-core/src/graph/store.rs
@@ -38,6 +38,79 @@ impl WriteLock {
     }
 }
 
+/// Every WAL-family sibling of the database at `db_path` that currently
+/// exists: `<db>.wal` plus the `<db>.wal.*` family.
+///
+/// Kuzu's on-disk WAL filename APPENDS ".wal" to the full db filename
+/// (e.g. "graph" -> "graph.wal", "docs.kuzu" -> "docs.kuzu.wal"). It does
+/// NOT replace the extension the way `Path::with_extension` does.
+fn wal_family_paths(db_path: &Path) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    let wal = PathBuf::from(format!("{}.wal", db_path.display()));
+    if wal.exists() {
+        found.push(wal);
+    }
+    if let (Some(parent), Some(name)) = (db_path.parent(), db_path.file_name()) {
+        let prefix = format!("{}.wal.", name.to_string_lossy());
+        if let Ok(entries) = std::fs::read_dir(parent) {
+            for e in entries.flatten() {
+                if e.file_name().to_string_lossy().starts_with(&prefix) {
+                    found.push(e.path());
+                }
+            }
+        }
+    }
+    found
+}
+
+/// Whether a process with this PID is currently running.
+fn pid_is_alive(pid: u32) -> bool {
+    let spid = sysinfo::Pid::from_u32(pid);
+    let mut sys = sysinfo::System::new();
+    sys.refresh_processes(sysinfo::ProcessesToUpdate::Some(&[spid]), true);
+    sys.process(spid).is_some()
+}
+
+/// If `db_path`'s graph shows signs of an unclean shutdown that can make
+/// Kuzu's WAL-replay-on-open crash the whole process, returns the dead
+/// holder's PID. `None` means it's safe to proceed to `Database::new` as
+/// normal.
+///
+/// Observed directly: a stale WAL left by a process that died without a
+/// clean checkpoint made `Database::new`'s WAL replay
+/// (`WALReplayer::replayNodeTableInsertRecord` -> `NodeTable::insert` ->
+/// `DiskArrayInternal::get`) hit `SIGBUS`/`EXC_BAD_ACCESS` and abort the
+/// whole process -- on a plain **read-only** open reached by an ordinary
+/// query, not just a risky write path, and before any `Result` existed for
+/// calling code to catch.
+///
+/// Two signals together, deliberately not either alone:
+/// - A WAL-family sibling exists (`wal_family_paths`) -- Kuzu did not
+///   complete a clean checkpoint before this graph was last closed. This
+///   alone is completely routine: a live writer mid-transaction, or a
+///   replay that would succeed fine, both leave a WAL sibling in place.
+/// - The write lock's recorded holder is confirmed dead (the OS reports no
+///   such process running right now). This is what turns "needs replay"
+///   (routine) into "the process that would have driven that
+///   replay/checkpoint died before finishing it" (suspect).
+///
+/// Requiring both keeps this from flagging the common, harmless case (a
+/// live writer's WAL, or a replay that would just work) while still
+/// catching the crash scenario above. A lock file that's absent, empty, or
+/// unparseable reads as "can't confirm a dead holder" and does not flag --
+/// conservative by design, since a false positive here means refusing to
+/// open a perfectly good graph.
+fn unclean_shutdown_wal_holder(db_path: &Path, lock_path: &Path) -> Option<u32> {
+    if wal_family_paths(db_path).is_empty() {
+        return None;
+    }
+    let holder = lockfile::read_holder(lock_path)?;
+    if pid_is_alive(holder.pid) {
+        return None; // holder is alive -- not our call to intervene
+    }
+    Some(holder.pid)
+}
+
 /// Persistent graph store backed by Kuzu.
 pub struct GraphStore {
     db: Database,
@@ -51,6 +124,15 @@ impl GraphStore {
             std::fs::create_dir_all(parent)?;
         }
         let lock_path = path.with_extension("lock");
+        if let Some(pid) = unclean_shutdown_wal_holder(path, &lock_path) {
+            anyhow::bail!(
+                "graph {} has an unreplayed WAL from process {pid}, which is no longer \
+                 running (unclean shutdown) -- refusing to open it directly, since WAL \
+                 replay in this state has been observed to crash the whole process with \
+                 SIGBUS; delete the graph directory to rebuild, or restore from a backup",
+                path.display()
+            );
+        }
         let db = Database::new(path, SystemConfig::default())
             .map_err(|e| anyhow::anyhow!("failed to open kuzu db: {e}"))?;
         let store = Self { db, lock_path };
@@ -73,6 +155,15 @@ impl GraphStore {
     /// Safe for concurrent access while a watcher is writing.
     pub fn open_read_only(path: &Path) -> Result<Self> {
         let lock_path = path.with_extension("lock");
+        if let Some(pid) = unclean_shutdown_wal_holder(path, &lock_path) {
+            anyhow::bail!(
+                "graph {} has an unreplayed WAL from process {pid}, which is no longer \
+                 running (unclean shutdown) -- refusing to open it directly, since WAL \
+                 replay in this state has been observed to crash the whole process with \
+                 SIGBUS; rebuild the graph or restore from a backup",
+                path.display()
+            );
+        }
         let config = SystemConfig::default()
             .read_only(true)
             .throw_on_wal_replay_failure(false);
@@ -264,4 +355,112 @@ fn count_query(conn: &Connection, query: &str) -> Result<u64> {
         }
     }
     Ok(0)
+}
+
+#[cfg(test)]
+mod unclean_shutdown_wal_tests {
+    use super::*;
+
+    fn write_holder_lock(lock_path: &Path, pid: u32) {
+        if let Some(parent) = lock_path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let info = lockfile::LockInfo {
+            pid,
+            role: "test".to_string(),
+            build_hash: "test".to_string(),
+            acquired_at: 0,
+        };
+        std::fs::write(lock_path, serde_json::to_string(&info).unwrap()).unwrap();
+    }
+
+    /// A PID essentially guaranteed not to be a running process, standing
+    /// in for "the write lock's recorded holder is dead" across these tests.
+    const DEAD_PID: u32 = 999_999;
+
+    #[test]
+    fn unclean_shutdown_wal_holder_flags_wal_plus_dead_holder() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("graph");
+        std::fs::write(dir.path().join("graph.wal"), b"wal").unwrap();
+        let lock_path = db_path.with_extension("lock");
+        write_holder_lock(&lock_path, DEAD_PID);
+
+        assert_eq!(
+            unclean_shutdown_wal_holder(&db_path, &lock_path),
+            Some(DEAD_PID)
+        );
+    }
+
+    #[test]
+    fn unclean_shutdown_wal_holder_ignores_a_live_holder() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("graph");
+        std::fs::write(dir.path().join("graph.wal"), b"wal").unwrap();
+        let lock_path = db_path.with_extension("lock");
+        write_holder_lock(&lock_path, std::process::id());
+
+        assert_eq!(
+            unclean_shutdown_wal_holder(&db_path, &lock_path),
+            None,
+            "a live writer's WAL is routine, not a signal to refuse opening"
+        );
+    }
+
+    #[test]
+    fn unclean_shutdown_wal_holder_ignores_no_wal_even_with_a_dead_holder() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("graph");
+        let lock_path = db_path.with_extension("lock");
+        write_holder_lock(&lock_path, DEAD_PID);
+
+        assert_eq!(
+            unclean_shutdown_wal_holder(&db_path, &lock_path),
+            None,
+            "a dead holder alone (no WAL) means nothing was left mid-replay"
+        );
+    }
+
+    #[test]
+    fn unclean_shutdown_wal_holder_ignores_a_wal_with_no_lock_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("graph");
+        std::fs::write(dir.path().join("graph.wal"), b"wal").unwrap();
+        let lock_path = db_path.with_extension("lock");
+
+        assert_eq!(
+            unclean_shutdown_wal_holder(&db_path, &lock_path),
+            None,
+            "can't confirm a dead holder without a lock payload to read -- conservative by design"
+        );
+    }
+
+    /// Regression test: a stale WAL from a dead process used to be handed
+    /// straight to `kuzu::Database::new`, which crashed the whole process
+    /// with SIGBUS deep inside WAL replay -- before any `Result` existed to
+    /// catch it. Both `open` and `open_read_only` must refuse up front
+    /// instead.
+    #[test]
+    fn open_refuses_a_graph_with_an_unreplayed_wal_from_a_dead_process() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("graph");
+        std::fs::write(
+            &db_path,
+            b"not a real kuzu db, doesn't matter for this test",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("graph.wal"), b"wal").unwrap();
+        write_holder_lock(&db_path.with_extension("lock"), DEAD_PID);
+
+        let err = GraphStore::open(&db_path)
+            .map(|_| ())
+            .expect_err("must refuse rather than attempt Database::new");
+        assert!(err.to_string().contains("unreplayed WAL"), "{err}");
+        assert!(err.to_string().contains(&DEAD_PID.to_string()), "{err}");
+
+        let err = GraphStore::open_read_only(&db_path)
+            .map(|_| ())
+            .expect_err("read-only open must refuse too");
+        assert!(err.to_string().contains("unreplayed WAL"), "{err}");
+    }
 }


### PR DESCRIPTION
## Problem

A stale WAL left by a process that died without a clean checkpoint can
crash the whole process with `SIGBUS` (`EXC_BAD_ACCESS` /
`KERN_PROTECTION_FAILURE`), deep inside Kuzu's WAL-replay-on-open
(`WALReplayer::replayNodeTableInsertRecord` -> `NodeTable::insert` ->
`DiskArrayInternal::get`) — on a plain **read-only** open reached by an
ordinary query, not just a risky write path, and before any `Result`
exists for calling code to catch.

Observed directly: three identical macOS crash reports while
indexing/searching a project whose watcher process had died uncleanly,
still holding the write lock's identity payload with a PID that was no
longer running. `open_read_only`'s existing
`.throw_on_wal_replay_failure(false)` doesn't help here — that flag
governs whether Kuzu throws a catchable exception on a WAL validation
failure; it has no bearing on a hard memory-safety crash inside the
replay code itself.

## Fix

Adds `GraphStore::unclean_shutdown_wal_holder(db_path, lock_path)`, which
flags a graph only when **both** signals are present:

- A WAL-family sibling exists (`<db>.wal`/`<db>.wal.*`) — Kuzu did not
  complete a clean checkpoint before the graph was last closed.
- The write lock's recorded holder (`lockfile::read_holder`) is confirmed
  dead via a fresh `sysinfo` process lookup.

Either signal alone is routine and must not be flagged: a live writer's
WAL mid-transaction is the common case and needs to proceed to a normal
`Database::new`/replay, or every ordinary write would start refusing
reads. It's specifically the *combination* — a WAL that will never be
finished checkpointing because the process that would have finished it is
gone — that matches the observed crash.

Wired into both `open()` and `open_read_only()`, before `Database::new`:
on a positive match, both refuse up front with a clear, actionable error
instead of attempting the risky replay.

## New dependency

`sysinfo` (infigraph-core only), for the PID-liveness check. Well
established, cross-platform, already used for exactly this purpose in
other Rust tooling.

## Testing

- 5 new unit tests covering `unclean_shutdown_wal_holder`'s four signal
  combinations (WAL+dead holder flags it; live holder, no WAL, or no lock
  file all correctly don't).
- 1 integration test proving both `open()` and `open_read_only()` refuse
  rather than attempt `Database::new` against a synthetic
  WAL-plus-dead-holder fixture.
- Full `infigraph-core --lib` suite (315 tests) green.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all --
  --check` clean.
- Full workspace `cargo check` clean (confirms the new dependency doesn't
  disturb anything downstream).

## Scope note

This fixes the code graph (`GraphStore`). The docs index (`DocStore`,
`docs.kuzu`) has the identical `Database::new` exposure but currently has
no cross-process identity-tracked lock — only an in-process `Mutex` — so
there's no reliable holder-liveness signal to check yet. Deliberately left
out of this PR rather than building a weaker heuristic; happy to follow up
once/if there's interest.