### PR TITLE
fix: make MCP panic logging non-panicking

### DIFF
--- a/crates/infigraph-mcp/src/lib.rs
+++ b/crates/infigraph-mcp/src/lib.rs
@@ -581,7 +581,9 @@ pub fn mcp_log(level: &str, msg: &str) {
         .map(|d| d.as_secs())
         .unwrap_or(0);
     let line = format!("[{ts}] {level}: {msg}");
-    eprintln!("{line}");
+    let stderr = std::io::stderr();
+    let mut stderr = stderr.lock();
+    let _ = writeln!(stderr, "{line}");
     let path = mcp_log_file_path();
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);

--- a/crates/infigraph-mcp/src/main.rs
+++ b/crates/infigraph-mcp/src/main.rs
@@ -192,7 +192,9 @@ fn install_panic_hook() {
             .unwrap_or_else(|| "unknown".to_string());
         let bt = std::backtrace::Backtrace::force_capture();
         mcp_log("PANIC", &format!("{payload} at {location}\n{bt}"));
-        eprintln!("PANIC: {payload} at {location}");
+        let stderr = io::stderr();
+        let mut stderr = stderr.lock();
+        let _ = writeln!(stderr, "PANIC: {payload} at {location}");
     }));
 }
 
@@ -386,4 +388,42 @@ fn handle_tools_list(id: &Value) -> Value {
 
 fn handle_tools_call(id: &Value, request: &Value) -> Value {
     infigraph_mcp::handle_tools_call(id, request)
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    const PANIC_HOOK_CHILD: &str = "INFIGRAPH_PANIC_HOOK_TEST_CHILD";
+
+    #[test]
+    fn panic_hook_tolerates_stderr_write_failure() {
+        if std::env::var_os(PANIC_HOOK_CHILD).is_some() {
+            install_panic_hook();
+            let result = std::panic::catch_unwind(|| panic!("panic hook test"));
+            assert!(result.is_err());
+            return;
+        }
+
+        let stderr = std::fs::OpenOptions::new()
+            .write(true)
+            .open("/dev/full")
+            .expect("failed to open /dev/full");
+        let home = tempfile::tempdir().expect("failed to create temporary home");
+        let status = std::process::Command::new(
+            std::env::current_exe().expect("failed to locate test executable"),
+        )
+        .args([
+            "--exact",
+            "tests::panic_hook_tolerates_stderr_write_failure",
+            "--nocapture",
+        ])
+        .env(PANIC_HOOK_CHILD, "1")
+        .env("HOME", home.path())
+        .stderr(std::process::Stdio::from(stderr))
+        .status()
+        .expect("failed to run panic hook test subprocess");
+
+        assert!(status.success(), "panic hook subprocess failed: {status}");
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the recursive panic path described in section 1 of #65.

The MCP panic hook currently logs through `eprintln!`. If stderr is unavailable or closed, `eprintln!` can panic while the process is already handling a panic. That re-enters the panic hook and can turn a recoverable panic into a hard abort.

This change makes stderr logging best-effort by writing through a locked stderr handle and ignoring write failures.

## Changes

- make `mcp_log` stderr writes non-panicking
- make the panic hook's direct stderr write non-panicking
- add a Linux regression test using `/dev/full` to simulate stderr write failure

## Scope

This PR intentionally addresses only the panic-hook recursion from #65.

It does not address the separate OOM, segfault, worker lifecycle, or core-dump-location observations from that issue.

## Validation

Passed locally:

- `cargo fmt --all -- --check`
- `git diff --check`

The targeted runtime test was attempted locally, but the build was blocked before reaching the MCP test by unrelated native dependency build failures in `usearch/simsimd` and then `lbug`.

The regression test is included so CI can exercise the panic path in the repository's supported build environment.