### PR TITLE
fix(graph): stop reusing a connection across independent bulk COPY writes

### DIFF
--- a/crates/infigraph-core/src/embed/mod.rs
+++ b/crates/infigraph-core/src/embed/mod.rs
@@ -398,6 +398,7 @@ pub fn load_embeddings(path: &Path) -> Result<Vec<(String, Vec<f32>)>> {
         pos += 4;
         let float_bytes = dim * 4;
         anyhow::ensure!(pos + float_bytes <= data.len(), "truncated embeddings file");
+        #[allow(clippy::chunks_exact_to_as_chunks)]
         let vec: Vec<f32> = data[pos..pos + float_bytes]
             .chunks_exact(4)
             .map(|chunk| f32::from_le_bytes(chunk.try_into().unwrap()))

--- a/crates/infigraph-core/src/graph/store_parquet.rs
+++ b/crates/infigraph-core/src/graph/store_parquet.rs
@@ -554,13 +554,13 @@ impl GraphStore {
             }
             let edge_pq = tmp.join(format!("infigraph_index_{}.parquet", table.to_lowercase()));
             copy_edges_with_bad_record_retry(
-                conn,
+                self,
                 table,
                 pairs.to_vec(),
                 src_label,
                 dst_label,
                 &edge_pq,
-            );
+            )?;
         }
 
         // Custom edge tables
@@ -574,13 +574,13 @@ impl GraphStore {
                 edge_name.to_lowercase()
             ));
             copy_edges_with_bad_record_retry(
-                conn,
+                self,
                 edge_name,
                 pairs.to_vec(),
                 "Symbol",
                 "Symbol",
                 &edge_pq,
-            );
+            )?;
         }
 
         // Cleanup node parquet files

--- a/crates/infigraph-core/src/graph/store_util.rs
+++ b/crates/infigraph-core/src/graph/store_util.rs
@@ -1,8 +1,10 @@
 use std::path::Path;
 
+use anyhow::Result;
 use kuzu::Connection;
 
 use crate::graph::parquet_loader;
+use crate::graph::store::GraphStore;
 
 /// How many bad-record-drop-and-retry cycles a bulk COPY gets before giving
 /// up and falling back to the slow per-row UNWIND path for whatever remains.
@@ -184,18 +186,30 @@ pub(crate) fn extract_bad_copy_value(err: &str) -> Option<&str> {
 /// retries are exhausted (`MAX_BAD_RECORD_RETRIES`) or the error isn't
 /// recognized as recoverable -- avoids paying the slow UNWIND path for an
 /// entire batch over a handful of bad rows.
+///
+/// Takes `store` rather than a borrowed `Connection`: a caught COPY failure
+/// can leave Kùzu's internal transaction bookkeeping on that connection in a
+/// state where the *next* statement fails immediately with `Invalid
+/// transaction type to rollback.` (observed in production -- a Symbol-table
+/// COPY's bad-PK retries left the connection wedged for the CALLS-table COPY
+/// that followed on the same connection). None of these bulk loads are
+/// wrapped in an explicit transaction, so sharing a connection across them
+/// buys no atomicity -- asking `store` for a fresh one every attempt is
+/// free of that risk and no more expensive (`GraphStore::connection` is a
+/// cheap `Connection::new` per call).
 pub(crate) fn copy_edges_with_bad_record_retry(
-    conn: &Connection,
+    store: &GraphStore,
     table: &str,
     mut pairs: Vec<(String, String)>,
     src_label: &str,
     dst_label: &str,
     edge_pq: &Path,
-) {
+) -> Result<()> {
     for attempt in 0..MAX_BAD_RECORD_RETRIES {
         if pairs.is_empty() {
-            return;
+            return Ok(());
         }
+        let conn = store.connection()?;
         let refs: Vec<(&str, &str)> = pairs
             .iter()
             .map(|(a, b)| (a.as_str(), b.as_str()))
@@ -206,7 +220,7 @@ pub(crate) fn copy_edges_with_bad_record_retry(
         match conn.query(&format!("COPY {table} FROM '{}'", fwd_slash_path(edge_pq))) {
             Ok(_) => {
                 let _ = std::fs::remove_file(edge_pq);
-                return;
+                return Ok(());
             }
             Err(e) => {
                 let msg = e.to_string();
@@ -227,12 +241,14 @@ pub(crate) fn copy_edges_with_bad_record_retry(
             }
         }
     }
+    let conn = store.connection()?;
     let refs: Vec<(&str, &str)> = pairs
         .iter()
         .map(|(a, b)| (a.as_str(), b.as_str()))
         .collect();
-    unwind_edges_from_pairs(conn, &refs, table, src_label, dst_label);
+    unwind_edges_from_pairs(&conn, &refs, table, src_label, dst_label);
     let _ = std::fs::remove_file(edge_pq);
+    Ok(())
 }
 
 pub fn classify_file(file: &str) -> &'static str {

--- a/crates/infigraph-core/src/resolve/calls.rs
+++ b/crates/infigraph-core/src/resolve/calls.rs
@@ -38,8 +38,8 @@ pub fn resolve_calls_incremental(
         symbol_map.entry(name).or_default().push((id, file, kind));
     }
 
-    let mut stats = resolve_with_map(&conn, extractions, &symbol_map, learned_store)?;
-    stats.inherits_resolved = resolve_inherits(&conn, extractions, &symbol_map)?;
+    let mut stats = resolve_with_map(store, &conn, extractions, &symbol_map, learned_store)?;
+    stats.inherits_resolved = resolve_inherits(store, extractions, &symbol_map)?;
     resolve_custom_edges(&conn, extractions, &symbol_map)?;
     Ok(stats)
 }
@@ -74,8 +74,8 @@ pub fn resolve_calls(
         }
     }
 
-    let mut stats = resolve_with_map(&conn, extractions, &symbol_map, learned_store)?;
-    stats.inherits_resolved = resolve_inherits(&conn, extractions, &symbol_map)?;
+    let mut stats = resolve_with_map(store, &conn, extractions, &symbol_map, learned_store)?;
+    stats.inherits_resolved = resolve_inherits(store, extractions, &symbol_map)?;
     resolve_custom_edges(&conn, extractions, &symbol_map)?;
     Ok(stats)
 }
@@ -230,6 +230,7 @@ fn write_external_calls(
 
 /// Caller must hold WriteLock.
 fn resolve_with_map(
+    store: &GraphStore,
     conn: &kuzu::Connection<'_>,
     extractions: &[FileExtraction],
     symbol_map: &HashMap<String, Vec<(String, String, String)>>,
@@ -607,7 +608,7 @@ fn resolve_with_map(
             .map(|(a, b)| (a.clone(), b.clone()))
             .collect();
         let pq_path = std::env::temp_dir().join("infigraph_resolve_calls.parquet");
-        copy_edges_with_bad_record_retry(conn, "CALLS", pairs, "Symbol", "Symbol", &pq_path);
+        copy_edges_with_bad_record_retry(store, "CALLS", pairs, "Symbol", "Symbol", &pq_path)?;
     }
 
     if !external_calls.is_empty() {
@@ -667,8 +668,8 @@ pub fn re_resolve_for_files(
         .collect();
 
     let filtered_owned: Vec<FileExtraction> = filtered.into_iter().cloned().collect();
-    let mut stats = resolve_with_map(&conn, &filtered_owned, &symbol_map, learned_store)?;
-    stats.inherits_resolved = resolve_inherits(&conn, &filtered_owned, &symbol_map)?;
+    let mut stats = resolve_with_map(store, &conn, &filtered_owned, &symbol_map, learned_store)?;
+    stats.inherits_resolved = resolve_inherits(store, &filtered_owned, &symbol_map)?;
     Ok(stats)
 }
 

--- a/crates/infigraph-core/src/resolve/inherits.rs
+++ b/crates/infigraph-core/src/resolve/inherits.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 
+use crate::graph::store::GraphStore;
 use crate::graph::store_util::copy_edges_with_bad_record_retry;
 use crate::model::{FileExtraction, RelationKind};
 
@@ -11,7 +12,7 @@ const TYPE_KINDS: &[&str] = &["Class", "Interface", "Struct", "Trait", "Enum"];
 
 /// Caller must hold WriteLock.
 pub(crate) fn resolve_inherits(
-    conn: &kuzu::Connection<'_>,
+    store: &GraphStore,
     extractions: &[FileExtraction],
     symbol_map: &HashMap<String, Vec<(String, String, String)>>,
 ) -> Result<usize> {
@@ -183,7 +184,7 @@ pub(crate) fn resolve_inherits(
         .map(|(a, b)| (a.clone(), b.clone()))
         .collect();
     let pq_path = std::env::temp_dir().join("infigraph_resolve_inherits.parquet");
-    copy_edges_with_bad_record_retry(conn, "INHERITS", pairs, "Symbol", "Symbol", &pq_path);
+    copy_edges_with_bad_record_retry(store, "INHERITS", pairs, "Symbol", "Symbol", &pq_path)?;
 
     Ok(count)
 }

--- a/crates/infigraph-core/src/scip/mod.rs
+++ b/crates/infigraph-core/src/scip/mod.rs
@@ -246,6 +246,13 @@ pub fn import_scip_index(
                 break;
             }
 
+            // Fresh connection every attempt -- a caught COPY failure can
+            // leave Kùzu's internal transaction bookkeeping wedged for
+            // whatever query runs next on that same connection (see
+            // `copy_edges_with_bad_record_retry`'s doc comment for the
+            // production incident this mirrors).
+            let conn = store.connection()?;
+
             let ids: Vec<&str> = remaining.iter().map(|(id, ..)| id.as_str()).collect();
             let names: Vec<&str> = remaining
                 .iter()
@@ -342,6 +349,9 @@ pub fn import_scip_index(
         }
 
         if !remaining.is_empty() {
+            // Fresh connection: the retry loop above may have just failed a
+            // COPY on whatever connection it was using.
+            let conn = store.connection()?;
             for chunk in remaining.chunks(CHUNK) {
                 let rows: Vec<String> = chunk
                     .iter()
@@ -370,6 +380,9 @@ pub fn import_scip_index(
     // Bulk write enrichments via UNWIND (updates can't use COPY FROM).
     // Only docstring is enriched -- see the note on `enrichments` above for
     // why start_line/end_line must never be written here.
+    // Fresh connection: the Symbol-COPY block above may have just failed a
+    // COPY on whatever connection it was using.
+    let conn = store.connection()?;
     for chunk in enrichments.chunks(CHUNK) {
         let rows: Vec<String> = chunk
             .iter()
@@ -468,13 +481,13 @@ pub fn import_scip_index(
         let edge_pq = tmp.join("infigraph_scip_calls.parquet");
         stats.references_added = calls_to_create.len();
         copy_edges_with_bad_record_retry(
-            &conn,
+            store,
             "CALLS",
             calls_to_create,
             "Symbol",
             "Symbol",
             &edge_pq,
-        );
+        )?;
     }
 
     // Pass 3: build INHERITS edges from SCIP's compiler-verified is_implementation
@@ -536,13 +549,13 @@ pub fn import_scip_index(
         let edge_pq = tmp.join("infigraph_scip_inherits.parquet");
         stats.relations_added = inherits_to_create.len();
         copy_edges_with_bad_record_retry(
-            &conn,
+            store,
             "INHERITS",
             inherits_to_create,
             "Symbol",
             "Symbol",
             &edge_pq,
-        );
+        )?;
     }
 
     // Persist learned corrections (if any were recorded)


### PR DESCRIPTION
Fixes intuit/infigraph#67 (Bug 1 of 2 described there — the connection-reuse wedging).

## What

`copy_edges_with_bad_record_retry` took a borrowed `Connection` and reused it across every retry attempt and the `UNWIND` fallback. None of these bulk loads are wrapped in an explicit transaction, so sharing the connection bought no atomicity — it only created exposure to whatever internal state a caught `COPY` failure leaves behind.

Observed in production: a `Symbol`-table `COPY`'s bad-PK-drop-and-retry cycle left the connection wedged such that the very next `COPY` on it (a different table, `CALLS`) failed immediately with Kùzu's internal `Invalid transaction type to rollback.` and fell back to the slower per-row `UNWIND` path. Self-healing (identical output either way, per `store_bench::test_parquet_quality`), so no data-loss exposure — but real and reproducible.

## Fix

`copy_edges_with_bad_record_retry` now takes `&GraphStore` instead of `&Connection` and asks for a fresh connection on every retry-loop iteration and before the `UNWIND` fallback — no "is this a retry" bookkeeping needed, since `GraphStore::connection()` already mints a fresh, cheap `Connection` on every call. The inline Symbol-node `COPY`-with-retry block in `import_scip_index` (a near-duplicate of the same pattern for nodes instead of edges) gets the same treatment.

Threading `&GraphStore` down to the one caller of this helper that didn't already have it (`resolve_with_map`) also let `resolve_inherits` drop its now-entirely-unused `&Connection` parameter.

Also silences one pre-existing, unrelated `clippy::chunks_exact_to_as_chunks` lint in `embed/mod.rs` that the workspace-wide pre-commit hook caught (newer clippy than this branch's last-tested baseline) — no behavior change, matches clippy's own suggested suppression.

## Testing

- `cargo test -p infigraph-core --lib` (310 tests, all pass)
- `cargo test -p infigraph-core --test resolve_calls` (15 tests, all pass — exercises `resolve_inherits`/`resolve_with_map`)
- `cargo test -p infigraph-core --test graph_queries` (`_conn`-suffixed tests, all pass)
- `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` both clean
- Pre-commit hook's perf suite (`write_lock_perf`, `groups_watch_perf`, `index_perf`) all pass

Bug 2 from intuit/infigraph#67 (the `raw_query` transaction no-op silently breaking `write_concerns`/`reflection` atomicity) is a separate, larger change (introducing `GraphStore::transaction()`) and will follow as its own PR.
