### PR TITLE
fix(graph): make concerns/reflection writes actually atomic

### DIFF
--- a/crates/infigraph-core/src/concerns/mod.rs
+++ b/crates/infigraph-core/src/concerns/mod.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use serde::Serialize;
 
-use crate::graph::GraphBackend;
+use crate::graph::{Concern, GraphBackend};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ConcernMatch {
@@ -290,7 +290,15 @@ pub fn detect_cross_cutting(backend: &dyn GraphBackend) -> Result<Vec<ConcernMat
     }
 
     if !matches.is_empty() {
-        write_concerns(backend, &matches)?;
+        let concerns: Vec<Concern> = matches
+            .iter()
+            .map(|m| Concern {
+                symbol_id: m.symbol_id.clone(),
+                kind: m.kind.to_string(),
+                detail: m.detail.clone(),
+            })
+            .collect();
+        backend.replace_concerns(&concerns)?;
     }
 
     Ok(matches)
@@ -303,31 +311,6 @@ fn extract_matched_line(docstring: &str, pattern: &str) -> String {
         }
     }
     pattern.to_string()
-}
-
-fn write_concerns(backend: &dyn GraphBackend, matches: &[ConcernMatch]) -> Result<()> {
-    backend.raw_query("BEGIN TRANSACTION")?;
-
-    let _ = backend.raw_query("MATCH (c:Concern) DETACH DELETE c");
-
-    for m in matches {
-        let sym_esc = crate::escape_str(&m.symbol_id);
-        let kind_esc = crate::escape_str(m.kind);
-        let detail_esc = crate::escape_str(&m.detail);
-        let concern_id = format!("{}::{}", m.symbol_id, m.kind);
-        let id_esc = crate::escape_str(&concern_id);
-
-        let _ = backend.raw_query(&format!(
-            "CREATE (c:Concern {{id: '{id_esc}', kind: '{kind_esc}', detail: '{detail_esc}'}})"
-        ));
-        let _ = backend.raw_query(&format!(
-            "MATCH (s:Symbol), (c:Concern) WHERE s.id = '{sym_esc}' AND c.id = '{id_esc}' CREATE (s)-[:HAS_CONCERN]->(c)"
-        ));
-    }
-
-    backend.raw_query("COMMIT")?;
-
-    Ok(())
 }
 
 pub fn format_concerns(matches: &[ConcernMatch]) -> String {

--- a/crates/infigraph-core/src/embed/mod.rs
+++ b/crates/infigraph-core/src/embed/mod.rs
@@ -398,6 +398,7 @@ pub fn load_embeddings(path: &Path) -> Result<Vec<(String, Vec<f32>)>> {
         pos += 4;
         let float_bytes = dim * 4;
         anyhow::ensure!(pos + float_bytes <= data.len(), "truncated embeddings file");
+        #[allow(clippy::chunks_exact_to_as_chunks)]
         let vec: Vec<f32> = data[pos..pos + float_bytes]
             .chunks_exact(4)
             .map(|chunk| f32::from_le_bytes(chunk.try_into().unwrap()))

--- a/crates/infigraph-core/src/graph/backend.rs
+++ b/crates/infigraph-core/src/graph/backend.rs
@@ -27,6 +27,25 @@ pub struct CallsServiceEdge {
     pub path: String,
 }
 
+/// A code-smell/concern match, to be written as a `Concern` node linked to
+/// its symbol via `HAS_CONCERN`.
+#[derive(Debug, Clone)]
+pub struct Concern {
+    pub symbol_id: String,
+    pub kind: String,
+    pub detail: String,
+}
+
+/// A resolved dynamic-dispatch/reflection site, to be written as a
+/// `RESOLVES_TO` edge from the calling symbol to its resolved target.
+#[derive(Debug, Clone)]
+pub struct ResolvesToEdge {
+    pub caller_symbol: String,
+    pub target: String,
+    pub mechanism: String,
+    pub config_source: String,
+}
+
 /// Backend-agnostic graph storage interface.
 ///
 /// KuzuBackend wraps the existing embedded Kùzu store (local mode).
@@ -239,6 +258,23 @@ pub trait GraphBackend: Send + Sync {
     /// directly (same design as `upsert_files_bulk`/`resolve_calls`). A
     /// no-op for an empty slice.
     fn write_calls_service_edges(&self, edges: &[CallsServiceEdge]) -> Result<()>;
+
+    /// Replace every recorded `Concern` with `concerns` as a single atomic
+    /// operation. Backend owns the transaction — callers don't manage
+    /// connections directly (same design as `write_calls_service_edges`).
+    ///
+    /// Previously implemented by issuing `BEGIN TRANSACTION`/`COMMIT`
+    /// through `raw_query` -- both backends' `raw_query` deliberately no-op
+    /// those (Kùzu: fresh connection per call, so control statements can't
+    /// span calls; Neo4j: transactions are driver-level, not Cypher), so
+    /// the delete-then-recreate was never actually atomic. A crash mid-loop
+    /// could delete all concerns and only recreate some of them.
+    fn replace_concerns(&self, concerns: &[Concern]) -> Result<()>;
+
+    /// Replace every recorded `RESOLVES_TO` edge with `edges` as a single
+    /// atomic operation. Same design and same prior non-atomicity bug as
+    /// `replace_concerns`.
+    fn replace_resolves_to(&self, edges: &[ResolvesToEdge]) -> Result<()>;
 
     // ── Resolve ──────────────────────────────────────────────────────
 

--- a/crates/infigraph-core/src/graph/kuzu_backend.rs
+++ b/crates/infigraph-core/src/graph/kuzu_backend.rs
@@ -7,7 +7,7 @@ use crate::learned::LearnedStore;
 use crate::model::FileExtraction;
 use crate::resolve::ResolveStats;
 
-use super::backend::{CallsServiceEdge, GraphBackend};
+use super::backend::{CallsServiceEdge, Concern, GraphBackend, ResolvesToEdge};
 use super::queries::GraphQuery;
 use super::store::GraphStore;
 use super::{
@@ -479,28 +479,62 @@ impl GraphBackend for KuzuBackend {
         if edges.is_empty() {
             return Ok(());
         }
-        let conn = self.store.connection()?;
-        conn.query("BEGIN TRANSACTION")
-            .map_err(|e| anyhow::anyhow!("failed to begin transaction: {e}"))?;
-        for edge in edges {
-            let src_esc = crate::escape_str(&edge.symbol_id);
-            let tgt_esc = crate::escape_str(&edge.target_id);
-            let method_esc = crate::escape_str(&edge.method);
-            let path_esc = crate::escape_str(&edge.path);
-            if let Err(e) = conn.query(&format!(
-                "MATCH (s:Symbol), (t:Symbol) WHERE s.id = '{src_esc}' AND t.id = '{tgt_esc}' \
-                 CREATE (s)-[:CALLS_SERVICE {{method: '{method_esc}', path: '{path_esc}', target_service: ''}}]->(t)"
-            )) {
-                // Roll back so we don't leave a half-applied batch or a
-                // dangling open transaction on this connection, then
-                // surface the real error instead of masking it.
-                let _ = conn.query("ROLLBACK");
-                return Err(anyhow::anyhow!("failed to create CALLS_SERVICE edge: {e}"));
+        self.store.transaction(|conn| {
+            for edge in edges {
+                let src_esc = crate::escape_str(&edge.symbol_id);
+                let tgt_esc = crate::escape_str(&edge.target_id);
+                let method_esc = crate::escape_str(&edge.method);
+                let path_esc = crate::escape_str(&edge.path);
+                conn.query(&format!(
+                    "MATCH (s:Symbol), (t:Symbol) WHERE s.id = '{src_esc}' AND t.id = '{tgt_esc}' \
+                     CREATE (s)-[:CALLS_SERVICE {{method: '{method_esc}', path: '{path_esc}', target_service: ''}}]->(t)"
+                ))
+                .map_err(|e| anyhow::anyhow!("failed to create CALLS_SERVICE edge: {e}"))?;
             }
-        }
-        conn.query("COMMIT")
-            .map_err(|e| anyhow::anyhow!("failed to commit CALLS_SERVICE edges: {e}"))?;
-        Ok(())
+            Ok(())
+        })
+    }
+
+    fn replace_concerns(&self, concerns: &[Concern]) -> Result<()> {
+        self.store.transaction(|conn| {
+            conn.query("MATCH (c:Concern) DETACH DELETE c")
+                .map_err(|e| anyhow::anyhow!("failed to clear existing concerns: {e}"))?;
+            for c in concerns {
+                let sym_esc = crate::escape_str(&c.symbol_id);
+                let kind_esc = crate::escape_str(&c.kind);
+                let detail_esc = crate::escape_str(&c.detail);
+                let concern_id = format!("{}::{}", c.symbol_id, c.kind);
+                let id_esc = crate::escape_str(&concern_id);
+                conn.query(&format!(
+                    "CREATE (c:Concern {{id: '{id_esc}', kind: '{kind_esc}', detail: '{detail_esc}'}})"
+                ))
+                .map_err(|e| anyhow::anyhow!("failed to create Concern node: {e}"))?;
+                conn.query(&format!(
+                    "MATCH (s:Symbol), (c:Concern) WHERE s.id = '{sym_esc}' AND c.id = '{id_esc}' CREATE (s)-[:HAS_CONCERN]->(c)"
+                ))
+                .map_err(|e| anyhow::anyhow!("failed to link Concern to its symbol: {e}"))?;
+            }
+            Ok(())
+        })
+    }
+
+    fn replace_resolves_to(&self, edges: &[ResolvesToEdge]) -> Result<()> {
+        self.store.transaction(|conn| {
+            conn.query("MATCH ()-[r:RESOLVES_TO]->() DELETE r")
+                .map_err(|e| anyhow::anyhow!("failed to clear existing RESOLVES_TO edges: {e}"))?;
+            for edge in edges {
+                let src_esc = crate::escape_str(&edge.caller_symbol);
+                let tgt_esc = crate::escape_str(&edge.target);
+                let mech_esc = crate::escape_str(&edge.mechanism);
+                let cfg_esc = crate::escape_str(&edge.config_source);
+                conn.query(&format!(
+                    "MATCH (s:Symbol), (t:Symbol) WHERE s.id = '{src_esc}' AND t.id = '{tgt_esc}' \
+                     CREATE (s)-[:RESOLVES_TO {{mechanism: '{mech_esc}', config_source: '{cfg_esc}'}}]->(t)"
+                ))
+                .map_err(|e| anyhow::anyhow!("failed to create RESOLVES_TO edge: {e}"))?;
+            }
+            Ok(())
+        })
     }
 
     // ── Resolve ──────────────────────────────────────────────────────

--- a/crates/infigraph-core/src/graph/mod.rs
+++ b/crates/infigraph-core/src/graph/mod.rs
@@ -15,7 +15,9 @@ pub(crate) mod store_util;
 mod store_write;
 pub mod test_templates;
 
-pub use backend::{filter_dead_code_candidates, CallsServiceEdge, GraphBackend};
+pub use backend::{
+    filter_dead_code_candidates, CallsServiceEdge, Concern, GraphBackend, ResolvesToEdge,
+};
 pub use cozo_store::CozoStore;
 pub use kuzu_backend::KuzuBackend;
 #[cfg(feature = "neo4j")]

--- a/crates/infigraph-core/src/graph/neo4j_backend.rs
+++ b/crates/infigraph-core/src/graph/neo4j_backend.rs
@@ -11,7 +11,7 @@ use crate::learned::LearnedStore;
 use crate::model::FileExtraction;
 use crate::resolve::ResolveStats;
 
-use super::backend::{CallsServiceEdge, GraphBackend};
+use super::backend::{CallsServiceEdge, Concern, GraphBackend, ResolvesToEdge};
 use super::{
     ApiSymbol, ArchitectureStats, BranchInfo, ComplexityRow, DeadCodeRow, FileDeps, FileHotspot,
     GraphStats, HubFunction, ImpactRow, KindCount, LanguageCount, ReferenceRow, SymbolDetail,
@@ -1856,6 +1856,70 @@ impl GraphBackend for Neo4jBackend {
             ),
         )
         .map_err(|e| anyhow::anyhow!("write_calls_service_edges failed: {e}"))?;
+        Ok(())
+    }
+
+    fn replace_concerns(&self, concerns: &[Concern]) -> Result<()> {
+        let concern_maps: Vec<HashMap<&str, String>> = concerns
+            .iter()
+            .map(|c| {
+                let mut m = HashMap::new();
+                m.insert("id", format!("{}::{}", c.symbol_id, c.kind));
+                m.insert("symbol_id", c.symbol_id.clone());
+                m.insert("kind", c.kind.clone());
+                m.insert("detail", c.detail.clone());
+                m
+            })
+            .collect();
+        // Single query: Neo4j auto-commits one Cypher statement atomically,
+        // so the delete and the recreate either both land or neither does --
+        // no driver-level transaction needed (same reasoning as
+        // `write_calls_service_edges`). Correct even when `concerns` is
+        // empty: the DETACH DELETE still runs, UNWIND over an empty list
+        // just contributes zero rows to what follows it.
+        self.block_on(
+            self.graph.run(
+                query(
+                    "MATCH (c:Concern) DETACH DELETE c \
+                     WITH 1 AS _cleared \
+                     UNWIND $concerns AS m \
+                     CREATE (c:Concern {id: m.id, kind: m.kind, detail: m.detail}) \
+                     WITH c, m \
+                     MATCH (s:Symbol) WHERE s.id = m.symbol_id \
+                     CREATE (s)-[:HAS_CONCERN]->(c)",
+                )
+                .param("concerns", concern_maps),
+            ),
+        )
+        .map_err(|e| anyhow::anyhow!("replace_concerns failed: {e}"))?;
+        Ok(())
+    }
+
+    fn replace_resolves_to(&self, edges: &[ResolvesToEdge]) -> Result<()> {
+        let edge_maps: Vec<HashMap<&str, String>> = edges
+            .iter()
+            .map(|e| {
+                let mut m = HashMap::new();
+                m.insert("caller_symbol", e.caller_symbol.clone());
+                m.insert("target", e.target.clone());
+                m.insert("mechanism", e.mechanism.clone());
+                m.insert("config_source", e.config_source.clone());
+                m
+            })
+            .collect();
+        self.block_on(
+            self.graph.run(
+                query(
+                    "MATCH ()-[r:RESOLVES_TO]->() DELETE r \
+                     WITH 1 AS _cleared \
+                     UNWIND $edges AS e \
+                     MATCH (s:Symbol), (t:Symbol) WHERE s.id = e.caller_symbol AND t.id = e.target \
+                     CREATE (s)-[:RESOLVES_TO {mechanism: e.mechanism, config_source: e.config_source}]->(t)",
+                )
+                .param("edges", edge_maps),
+            ),
+        )
+        .map_err(|e| anyhow::anyhow!("replace_resolves_to failed: {e}"))?;
         Ok(())
     }
 

--- a/crates/infigraph-core/src/graph/store.rs
+++ b/crates/infigraph-core/src/graph/store.rs
@@ -113,6 +113,34 @@ impl GraphStore {
         Connection::new(&self.db).map_err(|e| anyhow::anyhow!("failed to create connection: {e}"))
     }
 
+    /// Run `f` inside a real transaction: opens one connection, issues
+    /// `BEGIN TRANSACTION`, runs `f` against that connection, commits on
+    /// `Ok`, rolls back on `Err`.
+    ///
+    /// Use this for any write that must be atomic across more than one
+    /// statement. `KuzuBackend::raw_query`'s `BEGIN`/`COMMIT`/`ROLLBACK`
+    /// handling is deliberately a no-op (each call opens a fresh connection,
+    /// so transaction-control statements issued through it can never span
+    /// more than the one statement they're attached to) -- passing those
+    /// strings to `raw_query` does not get you a transaction. This method is
+    /// the real thing.
+    pub fn transaction<T>(&self, f: impl FnOnce(&Connection<'_>) -> Result<T>) -> Result<T> {
+        let conn = self.connection()?;
+        conn.query("BEGIN TRANSACTION")
+            .map_err(|e| anyhow::anyhow!("failed to begin transaction: {e}"))?;
+        match f(&conn) {
+            Ok(value) => {
+                conn.query("COMMIT")
+                    .map_err(|e| anyhow::anyhow!("failed to commit transaction: {e}"))?;
+                Ok(value)
+            }
+            Err(e) => {
+                let _ = conn.query("ROLLBACK");
+                Err(e)
+            }
+        }
+    }
+
     /// Remove all graph data for a deleted file.
     pub fn remove_file(&self, file: &str) -> Result<()> {
         let _lock = self.write_lock()?;

--- a/crates/infigraph-core/src/graph/store_parquet.rs
+++ b/crates/infigraph-core/src/graph/store_parquet.rs
@@ -554,13 +554,13 @@ impl GraphStore {
             }
             let edge_pq = tmp.join(format!("infigraph_index_{}.parquet", table.to_lowercase()));
             copy_edges_with_bad_record_retry(
-                conn,
+                self,
                 table,
                 pairs.to_vec(),
                 src_label,
                 dst_label,
                 &edge_pq,
-            );
+            )?;
         }
 
         // Custom edge tables
@@ -574,13 +574,13 @@ impl GraphStore {
                 edge_name.to_lowercase()
             ));
             copy_edges_with_bad_record_retry(
-                conn,
+                self,
                 edge_name,
                 pairs.to_vec(),
                 "Symbol",
                 "Symbol",
                 &edge_pq,
-            );
+            )?;
         }
 
         // Cleanup node parquet files

--- a/crates/infigraph-core/src/graph/store_util.rs
+++ b/crates/infigraph-core/src/graph/store_util.rs
@@ -1,8 +1,10 @@
 use std::path::Path;
 
+use anyhow::Result;
 use kuzu::Connection;
 
 use crate::graph::parquet_loader;
+use crate::graph::store::GraphStore;
 
 /// How many bad-record-drop-and-retry cycles a bulk COPY gets before giving
 /// up and falling back to the slow per-row UNWIND path for whatever remains.
@@ -184,18 +186,30 @@ pub(crate) fn extract_bad_copy_value(err: &str) -> Option<&str> {
 /// retries are exhausted (`MAX_BAD_RECORD_RETRIES`) or the error isn't
 /// recognized as recoverable -- avoids paying the slow UNWIND path for an
 /// entire batch over a handful of bad rows.
+///
+/// Takes `store` rather than a borrowed `Connection`: a caught COPY failure
+/// can leave Kùzu's internal transaction bookkeeping on that connection in a
+/// state where the *next* statement fails immediately with `Invalid
+/// transaction type to rollback.` (observed in production -- a Symbol-table
+/// COPY's bad-PK retries left the connection wedged for the CALLS-table COPY
+/// that followed on the same connection). None of these bulk loads are
+/// wrapped in an explicit transaction, so sharing a connection across them
+/// buys no atomicity -- asking `store` for a fresh one every attempt is
+/// free of that risk and no more expensive (`GraphStore::connection` is a
+/// cheap `Connection::new` per call).
 pub(crate) fn copy_edges_with_bad_record_retry(
-    conn: &Connection,
+    store: &GraphStore,
     table: &str,
     mut pairs: Vec<(String, String)>,
     src_label: &str,
     dst_label: &str,
     edge_pq: &Path,
-) {
+) -> Result<()> {
     for attempt in 0..MAX_BAD_RECORD_RETRIES {
         if pairs.is_empty() {
-            return;
+            return Ok(());
         }
+        let conn = store.connection()?;
         let refs: Vec<(&str, &str)> = pairs
             .iter()
             .map(|(a, b)| (a.as_str(), b.as_str()))
@@ -206,7 +220,7 @@ pub(crate) fn copy_edges_with_bad_record_retry(
         match conn.query(&format!("COPY {table} FROM '{}'", fwd_slash_path(edge_pq))) {
             Ok(_) => {
                 let _ = std::fs::remove_file(edge_pq);
-                return;
+                return Ok(());
             }
             Err(e) => {
                 let msg = e.to_string();
@@ -227,12 +241,14 @@ pub(crate) fn copy_edges_with_bad_record_retry(
             }
         }
     }
+    let conn = store.connection()?;
     let refs: Vec<(&str, &str)> = pairs
         .iter()
         .map(|(a, b)| (a.as_str(), b.as_str()))
         .collect();
-    unwind_edges_from_pairs(conn, &refs, table, src_label, dst_label);
+    unwind_edges_from_pairs(&conn, &refs, table, src_label, dst_label);
     let _ = std::fs::remove_file(edge_pq);
+    Ok(())
 }
 
 pub fn classify_file(file: &str) -> &'static str {

--- a/crates/infigraph-core/src/reflection/mod.rs
+++ b/crates/infigraph-core/src/reflection/mod.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::path::Path;
 
-use crate::graph::GraphBackend;
+use crate::graph::{GraphBackend, ResolvesToEdge};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ReflectionSite {
@@ -143,7 +143,19 @@ pub fn detect_reflection_sites(
     }
 
     if !sites.is_empty() {
-        write_resolves_to(backend, &sites)?;
+        let edges: Vec<ResolvesToEdge> = sites
+            .iter()
+            .filter_map(|site| {
+                let target = site.resolved_to.as_ref()?;
+                Some(ResolvesToEdge {
+                    caller_symbol: site.caller_symbol.clone(),
+                    target: target.clone(),
+                    mechanism: site.mechanism.to_string(),
+                    config_source: site.config_source.clone().unwrap_or_default(),
+                })
+            })
+            .collect();
+        backend.replace_resolves_to(&edges)?;
     }
 
     Ok(sites)
@@ -338,30 +350,6 @@ fn try_resolve(
     }
 
     (None, None)
-}
-
-fn write_resolves_to(backend: &dyn GraphBackend, sites: &[ReflectionSite]) -> Result<()> {
-    backend.raw_query("BEGIN TRANSACTION")?;
-
-    let _ = backend.raw_query("MATCH ()-[r:RESOLVES_TO]->() DELETE r");
-
-    for site in sites {
-        if let Some(ref target) = site.resolved_to {
-            let src_esc = crate::escape_str(&site.caller_symbol);
-            let tgt_esc = crate::escape_str(target);
-            let mech_esc = crate::escape_str(site.mechanism);
-            let cfg_esc = crate::escape_str(site.config_source.as_deref().unwrap_or(""));
-
-            let _ = backend.raw_query(&format!(
-                "MATCH (s:Symbol), (t:Symbol) WHERE s.id = '{src_esc}' AND t.id = '{tgt_esc}' \
-                 CREATE (s)-[:RESOLVES_TO {{mechanism: '{mech_esc}', config_source: '{cfg_esc}'}}]->(t)"
-            ));
-        }
-    }
-
-    backend.raw_query("COMMIT")?;
-
-    Ok(())
 }
 
 pub fn format_reflection_sites(sites: &[ReflectionSite]) -> String {

--- a/crates/infigraph-core/src/resolve/calls.rs
+++ b/crates/infigraph-core/src/resolve/calls.rs
@@ -38,8 +38,8 @@ pub fn resolve_calls_incremental(
         symbol_map.entry(name).or_default().push((id, file, kind));
     }
 
-    let mut stats = resolve_with_map(&conn, extractions, &symbol_map, learned_store)?;
-    stats.inherits_resolved = resolve_inherits(&conn, extractions, &symbol_map)?;
+    let mut stats = resolve_with_map(store, &conn, extractions, &symbol_map, learned_store)?;
+    stats.inherits_resolved = resolve_inherits(store, extractions, &symbol_map)?;
     resolve_custom_edges(&conn, extractions, &symbol_map)?;
     Ok(stats)
 }
@@ -74,8 +74,8 @@ pub fn resolve_calls(
         }
     }
 
-    let mut stats = resolve_with_map(&conn, extractions, &symbol_map, learned_store)?;
-    stats.inherits_resolved = resolve_inherits(&conn, extractions, &symbol_map)?;
+    let mut stats = resolve_with_map(store, &conn, extractions, &symbol_map, learned_store)?;
+    stats.inherits_resolved = resolve_inherits(store, extractions, &symbol_map)?;
     resolve_custom_edges(&conn, extractions, &symbol_map)?;
     Ok(stats)
 }
@@ -230,6 +230,7 @@ fn write_external_calls(
 
 /// Caller must hold WriteLock.
 fn resolve_with_map(
+    store: &GraphStore,
     conn: &kuzu::Connection<'_>,
     extractions: &[FileExtraction],
     symbol_map: &HashMap<String, Vec<(String, String, String)>>,
@@ -607,7 +608,7 @@ fn resolve_with_map(
             .map(|(a, b)| (a.clone(), b.clone()))
             .collect();
         let pq_path = std::env::temp_dir().join("infigraph_resolve_calls.parquet");
-        copy_edges_with_bad_record_retry(conn, "CALLS", pairs, "Symbol", "Symbol", &pq_path);
+        copy_edges_with_bad_record_retry(store, "CALLS", pairs, "Symbol", "Symbol", &pq_path)?;
     }
 
     if !external_calls.is_empty() {
@@ -667,8 +668,8 @@ pub fn re_resolve_for_files(
         .collect();
 
     let filtered_owned: Vec<FileExtraction> = filtered.into_iter().cloned().collect();
-    let mut stats = resolve_with_map(&conn, &filtered_owned, &symbol_map, learned_store)?;
-    stats.inherits_resolved = resolve_inherits(&conn, &filtered_owned, &symbol_map)?;
+    let mut stats = resolve_with_map(store, &conn, &filtered_owned, &symbol_map, learned_store)?;
+    stats.inherits_resolved = resolve_inherits(store, &filtered_owned, &symbol_map)?;
     Ok(stats)
 }
 

--- a/crates/infigraph-core/src/resolve/inherits.rs
+++ b/crates/infigraph-core/src/resolve/inherits.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 
+use crate::graph::store::GraphStore;
 use crate::graph::store_util::copy_edges_with_bad_record_retry;
 use crate::model::{FileExtraction, RelationKind};
 
@@ -11,7 +12,7 @@ const TYPE_KINDS: &[&str] = &["Class", "Interface", "Struct", "Trait", "Enum"];
 
 /// Caller must hold WriteLock.
 pub(crate) fn resolve_inherits(
-    conn: &kuzu::Connection<'_>,
+    store: &GraphStore,
     extractions: &[FileExtraction],
     symbol_map: &HashMap<String, Vec<(String, String, String)>>,
 ) -> Result<usize> {
@@ -183,7 +184,7 @@ pub(crate) fn resolve_inherits(
         .map(|(a, b)| (a.clone(), b.clone()))
         .collect();
     let pq_path = std::env::temp_dir().join("infigraph_resolve_inherits.parquet");
-    copy_edges_with_bad_record_retry(conn, "INHERITS", pairs, "Symbol", "Symbol", &pq_path);
+    copy_edges_with_bad_record_retry(store, "INHERITS", pairs, "Symbol", "Symbol", &pq_path)?;
 
     Ok(count)
 }

--- a/crates/infigraph-core/src/scip/mod.rs
+++ b/crates/infigraph-core/src/scip/mod.rs
@@ -246,6 +246,13 @@ pub fn import_scip_index(
                 break;
             }
 
+            // Fresh connection every attempt -- a caught COPY failure can
+            // leave Kùzu's internal transaction bookkeeping wedged for
+            // whatever query runs next on that same connection (see
+            // `copy_edges_with_bad_record_retry`'s doc comment for the
+            // production incident this mirrors).
+            let conn = store.connection()?;
+
             let ids: Vec<&str> = remaining.iter().map(|(id, ..)| id.as_str()).collect();
             let names: Vec<&str> = remaining
                 .iter()
@@ -342,6 +349,9 @@ pub fn import_scip_index(
         }
 
         if !remaining.is_empty() {
+            // Fresh connection: the retry loop above may have just failed a
+            // COPY on whatever connection it was using.
+            let conn = store.connection()?;
             for chunk in remaining.chunks(CHUNK) {
                 let rows: Vec<String> = chunk
                     .iter()
@@ -370,6 +380,9 @@ pub fn import_scip_index(
     // Bulk write enrichments via UNWIND (updates can't use COPY FROM).
     // Only docstring is enriched -- see the note on `enrichments` above for
     // why start_line/end_line must never be written here.
+    // Fresh connection: the Symbol-COPY block above may have just failed a
+    // COPY on whatever connection it was using.
+    let conn = store.connection()?;
     for chunk in enrichments.chunks(CHUNK) {
         let rows: Vec<String> = chunk
             .iter()
@@ -468,13 +481,13 @@ pub fn import_scip_index(
         let edge_pq = tmp.join("infigraph_scip_calls.parquet");
         stats.references_added = calls_to_create.len();
         copy_edges_with_bad_record_retry(
-            &conn,
+            store,
             "CALLS",
             calls_to_create,
             "Symbol",
             "Symbol",
             &edge_pq,
-        );
+        )?;
     }
 
     // Pass 3: build INHERITS edges from SCIP's compiler-verified is_implementation
@@ -536,13 +549,13 @@ pub fn import_scip_index(
         let edge_pq = tmp.join("infigraph_scip_inherits.parquet");
         stats.relations_added = inherits_to_create.len();
         copy_edges_with_bad_record_retry(
-            &conn,
+            store,
             "INHERITS",
             inherits_to_create,
             "Symbol",
             "Symbol",
             &edge_pq,
-        );
+        )?;
     }
 
     // Persist learned corrections (if any were recorded)

--- a/crates/infigraph-core/tests/concerns_reflection_atomic_writes.rs
+++ b/crates/infigraph-core/tests/concerns_reflection_atomic_writes.rs
@@ -1,0 +1,265 @@
+use infigraph_core::graph::{Concern, GraphBackend, GraphStore, KuzuBackend, ResolvesToEdge};
+use infigraph_core::model::{FileExtraction, Span, Symbol, SymbolKind};
+
+fn span(file: &str, start: u32, end: u32) -> Span {
+    Span {
+        file: file.to_string(),
+        start_line: start,
+        start_col: 0,
+        end_line: end,
+        end_col: 0,
+    }
+}
+
+fn sym(id: &str, name: &str, file: &str, start: u32, end: u32) -> Symbol {
+    Symbol {
+        id: id.to_string(),
+        name: name.to_string(),
+        kind: SymbolKind::Function,
+        span: span(file, start, end),
+        signature_hash: format!("hash_{id}"),
+        parent: None,
+        language: "python".to_string(),
+        visibility: Some("public".to_string()),
+        docstring: None,
+        complexity: 1,
+        parameters: None,
+        return_type: None,
+    }
+}
+
+fn seed_two_symbols(backend: &KuzuBackend) {
+    let a = FileExtraction {
+        file: "a.py".to_string(),
+        language: "python".to_string(),
+        content_hash: "h1".to_string(),
+        symbols: vec![sym("a.py::handler", "handler", "a.py", 1, 5)],
+        relations: vec![],
+        statements: vec![],
+    };
+    let b = FileExtraction {
+        file: "b.py".to_string(),
+        language: "python".to_string(),
+        content_hash: "h2".to_string(),
+        symbols: vec![sym("b.py::worker", "worker", "b.py", 1, 5)],
+        relations: vec![],
+        statements: vec![],
+    };
+    backend.upsert_file(&a).unwrap();
+    backend.upsert_file(&b).unwrap();
+}
+
+#[test]
+fn replace_concerns_creates_all_concerns_and_edges() {
+    let tmp = tempfile::tempdir().unwrap();
+    let backend = KuzuBackend::open(&tmp.path().join("graph")).unwrap();
+    seed_two_symbols(&backend);
+
+    let concerns = vec![
+        Concern {
+            symbol_id: "a.py::handler".to_string(),
+            kind: "auth".to_string(),
+            detail: "requires login".to_string(),
+        },
+        Concern {
+            symbol_id: "b.py::worker".to_string(),
+            kind: "caching".to_string(),
+            detail: "cached result".to_string(),
+        },
+    ];
+    backend.replace_concerns(&concerns).unwrap();
+
+    let rows = backend
+        .raw_query("MATCH (s:Symbol)-[:HAS_CONCERN]->(c:Concern) RETURN s.id, c.kind ORDER BY s.id")
+        .unwrap();
+    assert_eq!(rows.len(), 2, "expected both concerns linked, got {rows:?}");
+    assert_eq!(rows[0][0], "a.py::handler");
+    assert_eq!(rows[0][1], "auth");
+    assert_eq!(rows[1][0], "b.py::worker");
+    assert_eq!(rows[1][1], "caching");
+}
+
+#[test]
+fn replace_concerns_replaces_rather_than_accumulates() {
+    let tmp = tempfile::tempdir().unwrap();
+    let backend = KuzuBackend::open(&tmp.path().join("graph")).unwrap();
+    seed_two_symbols(&backend);
+
+    backend
+        .replace_concerns(&[Concern {
+            symbol_id: "a.py::handler".to_string(),
+            kind: "auth".to_string(),
+            detail: "first run".to_string(),
+        }])
+        .unwrap();
+
+    backend
+        .replace_concerns(&[Concern {
+            symbol_id: "b.py::worker".to_string(),
+            kind: "caching".to_string(),
+            detail: "second run".to_string(),
+        }])
+        .unwrap();
+
+    let rows = backend
+        .raw_query("MATCH (c:Concern) RETURN c.kind")
+        .unwrap();
+    assert_eq!(
+        rows.len(),
+        1,
+        "second call must replace, not accumulate on top of, the first: {rows:?}"
+    );
+    assert_eq!(rows[0][0], "caching");
+}
+
+/// Regression test for the live atomicity bug this session found: the old
+/// `write_concerns` issued `BEGIN TRANSACTION`/`COMMIT` through `raw_query`,
+/// which both backends deliberately no-op -- so a failure partway through
+/// the recreate loop left the DETACH DELETE committed but only some of the
+/// new concerns written, permanently losing the rest. This forces a
+/// mid-batch failure (a duplicate Concern id, which collides on Kùzu's
+/// primary key) and asserts the pre-existing concern survives -- proving
+/// the whole batch rolled back together rather than partially landing.
+#[test]
+fn replace_concerns_rolls_back_atomically_on_mid_batch_failure() {
+    let tmp = tempfile::tempdir().unwrap();
+    let backend = KuzuBackend::open(&tmp.path().join("graph")).unwrap();
+    seed_two_symbols(&backend);
+
+    backend
+        .replace_concerns(&[Concern {
+            symbol_id: "a.py::handler".to_string(),
+            kind: "auth".to_string(),
+            detail: "pre-existing, must survive the failed call below".to_string(),
+        }])
+        .unwrap();
+
+    // Two concerns with the same symbol_id+kind produce the same Concern.id
+    // ("b.py::worker::caching") -- the second CREATE collides with the
+    // first on Kùzu's primary key and fails the whole transaction.
+    let result = backend.replace_concerns(&[
+        Concern {
+            symbol_id: "b.py::worker".to_string(),
+            kind: "caching".to_string(),
+            detail: "first".to_string(),
+        },
+        Concern {
+            symbol_id: "b.py::worker".to_string(),
+            kind: "caching".to_string(),
+            detail: "duplicate id -- forces a mid-batch failure".to_string(),
+        },
+    ]);
+    assert!(
+        result.is_err(),
+        "a duplicate Concern id must fail, not silently succeed"
+    );
+
+    let rows = backend
+        .raw_query("MATCH (c:Concern) RETURN c.kind, c.detail")
+        .unwrap();
+    assert_eq!(
+        rows.len(),
+        1,
+        "the failed call must roll back completely -- the old concern must \
+         still be present and no partial new concerns should have landed: {rows:?}"
+    );
+    assert_eq!(rows[0][0], "auth");
+    assert_eq!(
+        rows[0][1], "pre-existing, must survive the failed call below",
+        "the old concern's own data must be untouched, not deleted-then-lost"
+    );
+}
+
+#[test]
+fn replace_resolves_to_creates_edges_and_skips_unresolved() {
+    let tmp = tempfile::tempdir().unwrap();
+    let backend = KuzuBackend::open(&tmp.path().join("graph")).unwrap();
+    seed_two_symbols(&backend);
+
+    let edges = vec![ResolvesToEdge {
+        caller_symbol: "a.py::handler".to_string(),
+        target: "b.py::worker".to_string(),
+        mechanism: "importlib".to_string(),
+        config_source: String::new(),
+    }];
+    backend.replace_resolves_to(&edges).unwrap();
+
+    let rows = backend
+        .raw_query("MATCH (:Symbol)-[r:RESOLVES_TO]->(:Symbol) RETURN r.mechanism")
+        .unwrap();
+    assert_eq!(rows.len(), 1, "expected exactly one edge: {rows:?}");
+    assert_eq!(rows[0][0], "importlib");
+}
+
+#[test]
+fn replace_resolves_to_empty_still_clears_old_edges() {
+    let tmp = tempfile::tempdir().unwrap();
+    let backend = KuzuBackend::open(&tmp.path().join("graph")).unwrap();
+    seed_two_symbols(&backend);
+
+    backend
+        .replace_resolves_to(&[ResolvesToEdge {
+            caller_symbol: "a.py::handler".to_string(),
+            target: "b.py::worker".to_string(),
+            mechanism: "importlib".to_string(),
+            config_source: String::new(),
+        }])
+        .unwrap();
+
+    // Matches the original free function's semantics: called whenever the
+    // analysis pass ran at all (non-empty `sites`), even if none of them
+    // resolved this time -- old edges must still be cleared.
+    backend.replace_resolves_to(&[]).unwrap();
+
+    let rows = backend
+        .raw_query("MATCH (:Symbol)-[r:RESOLVES_TO]->(:Symbol) RETURN r.mechanism")
+        .unwrap();
+    assert!(
+        rows.is_empty(),
+        "an empty edge list must still clear previously-written edges: {rows:?}"
+    );
+}
+
+#[test]
+fn graph_store_transaction_commits_on_ok() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = GraphStore::open(&tmp.path().join("graph")).unwrap();
+
+    store
+        .transaction(|conn| {
+            conn.query("CREATE (:Concern {id: 'x', kind: 'k', detail: 'd'})")
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            Ok(())
+        })
+        .unwrap();
+
+    let conn = store.connection().unwrap();
+    let rows: Vec<_> = conn
+        .query("MATCH (c:Concern) RETURN c.id")
+        .unwrap()
+        .collect();
+    assert_eq!(rows.len(), 1);
+}
+
+#[test]
+fn graph_store_transaction_rolls_back_on_err() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = GraphStore::open(&tmp.path().join("graph")).unwrap();
+
+    let result: anyhow::Result<()> = store.transaction(|conn| {
+        conn.query("CREATE (:Concern {id: 'x', kind: 'k', detail: 'd'})")
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        anyhow::bail!("simulated failure after the write");
+    });
+    assert!(result.is_err());
+
+    let conn = store.connection().unwrap();
+    let rows: Vec<_> = conn
+        .query("MATCH (c:Concern) RETURN c.id")
+        .unwrap()
+        .collect();
+    assert!(
+        rows.is_empty(),
+        "the write before the simulated failure must have been rolled back: {rows:?}"
+    );
+}


### PR DESCRIPTION
Fixes intuit/infigraph#67 (Bug 2 of 2). Depends on #68 (this branch is stacked on it) -- the diff will shrink to just this PR's changes once #68 merges.

## What

`write_concerns` and reflection's equivalent `write_resolves_to` issued `BEGIN TRANSACTION`/`COMMIT` through `raw_query`, believing that made their delete-then-recreate loop atomic. It never did:

- `KuzuBackend::raw_query` opens a fresh connection per call, so transaction-control statements issued through it can never span more than the one statement they're attached to.
- `Neo4jBackend::raw_query` no-ops the same statements for a different reason (Neo4j transactions are driver-level, not Cypher).

Both backends' `raw_query` already document this and deliberately no-op those statements rather than error -- but neither caller knew that, so every individual `DETACH DELETE`/`CREATE` in the loop auto-committed independently. **A crash mid-loop today already means the old concerns/`RESOLVES_TO` edges are gone and only some of the new ones landed** -- live data-loss exposure, not hypothetical.

## Fix

- `GraphStore::transaction<T>(&self, f: impl FnOnce(&Connection) -> Result<T>) -> Result<T>` -- opens one connection, issues a real `BEGIN TRANSACTION`, runs `f` against it, commits on `Ok`, rolls back on `Err`.
- Two new `GraphBackend` trait methods, `replace_concerns` and `replace_resolves_to`, following the same "backend owns the transaction" design as the existing `write_calls_service_edges`. New `Concern`/`ResolvesToEdge` structs live in `backend.rs` (mirroring `CallsServiceEdge`) rather than reusing the analysis-pass types (`ConcernMatch`/`ReflectionSite`), keeping those out of the storage layer.
- `KuzuBackend` implements both via the new `store.transaction()`.
- `Neo4jBackend` implements both as a single chained Cypher statement (delete + `UNWIND`-based recreate) -- matches `write_calls_service_edges`'s existing precedent of "one auto-committed statement, no driver-level transaction needed" for that backend.
- `write_calls_service_edges` itself also migrates onto `store.transaction()`, removing its hand-rolled `BEGIN`/loop/`COMMIT`/`ROLLBACK` boilerplate (same behavior, no longer duplicated).
- The free `write_concerns`/`write_resolves_to` functions in `concerns/mod.rs`/`reflection/mod.rs` are deleted; their one call site each now builds the new backend-layer structs and calls the trait method directly.

## Testing

New file `tests/concerns_reflection_atomic_writes.rs`, 7 tests:

- `replace_concerns_rolls_back_atomically_on_mid_batch_failure` -- forces a mid-batch failure (two `Concern`s with the same id, colliding on Kùzu's primary key) and asserts a pre-existing concern survives untouched, proving the whole batch rolls back together. **This fails against the pre-fix code** (the old per-row `let _ =` swallowed the error entirely and always returned `Ok`, let alone rolled back).
- Direct commit/rollback tests for `GraphStore::transaction()`.
- Basic correctness tests for both new trait methods (creates edges, replaces rather than accumulates, empty-input still clears old data).

All pass under both default and `--features remote` (neo4j). `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` both clean under both feature sets. Pre-commit hook's perf suite (`write_lock_perf`, `groups_watch_perf`, `index_perf`) all pass.

Note: the Neo4j-side Cypher hasn't been run against a live instance -- matches this codebase's existing precedent (the reference `write_calls_service_edges` Neo4j test is `#[ignore]`d for the same reason).
