### PR TITLE
chore(deps): bump lbug (kuzu) 0.16.0 -> 0.19.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2867,15 +2867,16 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lbug"
-version = "0.16.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f7c64a35d4c7d5adb75354c949464d83123e874db641315b988a8c63e46440"
+checksum = "a7a032d5968ac2260545e8c5cf05a123559de2c6ba2bd0dde11c0ed958dfa172"
 dependencies = [
  "cmake",
  "cxx",
  "cxx-build",
  "rust_decimal",
  "rustversion",
+ "serde_json",
  "time",
  "uuid",
 ]

--- a/crates/infigraph-cli/Cargo.toml
+++ b/crates/infigraph-cli/Cargo.toml
@@ -60,7 +60,7 @@ ureq = "2"
 sha2 = "0.10"
 chrono = { version = "0.4", features = ["serde"] }
 cozo = { version = "0.7.6", features = ["storage-sqlite"] }
-kuzu = { package = "lbug", version = "= 0.16.0" }
+kuzu = { package = "lbug", version = "= 0.19.1" }
 fs2 = "0.4"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/infigraph-core/Cargo.toml
+++ b/crates/infigraph-core/Cargo.toml
@@ -18,7 +18,7 @@ anyhow.workspace = true
 thiserror.workspace = true
 # lbug is a maintained fork of Kuzu (columnar embedded graph DB), published to crates.io.
 # Aliased as `kuzu` to match the upstream Kuzu API surface used throughout the codebase.
-kuzu = { package = "lbug", version = "= 0.16.0" }
+kuzu = { package = "lbug", version = "= 0.19.1" }
 cozo = { version = "0.7.6", features = ["storage-sqlite"] }
 rayon = "1"
 sha2 = "0.10"

--- a/crates/infigraph-docs/Cargo.toml
+++ b/crates/infigraph-docs/Cargo.toml
@@ -18,7 +18,7 @@ anyhow.workspace = true
 rayon = "1"
 sha2 = "0.10"
 regex = "1"
-kuzu = { package = "lbug", version = "= 0.16.0" }
+kuzu = { package = "lbug", version = "= 0.19.1" }
 parquet = "58.3"
 arrow = { version = "58.3", features = ["prettyprint"] }
 tempfile = "3"

--- a/crates/infigraph-mcp/tests/concurrent_writer_reader.rs
+++ b/crates/infigraph-mcp/tests/concurrent_writer_reader.rs
@@ -1,0 +1,160 @@
+//! Deterministic (not incidental/ambient) reproduction of a concurrency question
+//! left open by the paused lbug 0.16.0 -> 0.18.3 version-bump investigation:
+//! does a read-only query return CORRECT data (or fail cleanly) when a writer
+//! is ACTIVELY reindexing concurrently, the way `infigraph watch` holds one
+//! connection open and reindexes on every file-change batch
+//! (crates/infigraph-core/src/watch/mod.rs)?
+//!
+//! Goes directly through `KuzuBackend::open_read_only` + `get_symbols_for_search`
+//! (`MATCH (s:Symbol) RETURN ...`) -- the exact query at the heart of the
+//! original finding (crates/infigraph-mcp/src/tools/search.rs's
+//! `get_search_data_local` calls this to build BM25/vector search) -- rather
+//! than through the full `search` MCP tool, whose BM25/embeddings rebuild cost
+//! made two earlier attempts too slow to get enough concurrent read samples
+//! (4 samples in 8s of wall-clock). This version does hundreds of reads per
+//! second by skipping that layer entirely.
+//!
+//! One file (`mod_stable.py`) is indexed once and never touched again -- its
+//! symbol's presence is guaranteed data-wise for the whole test, so any read
+//! failure to find it while the writer churns a SEPARATE file can only be a
+//! concurrent-access artifact, not a fixture bug.
+
+use infigraph_core::graph::{GraphBackend, KuzuBackend};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::mpsc;
+use std::time::Duration;
+
+fn write_fixture(dir: &std::path::Path, filename: &str, content: &str) {
+    std::fs::write(dir.join(filename), content).expect("write fixture file");
+}
+
+fn index_full(prism: &mut infigraph_core::Infigraph) {
+    prism.index().expect("index");
+}
+
+#[test]
+fn concurrent_writer_reader_raw_query_correctness_under_load() {
+    let project = tempfile::tempdir().expect("project tmpdir");
+    let root = project.path().to_path_buf();
+    let db_path = root.join(".infigraph").join("graph");
+
+    write_fixture(&root, "mod_stable.py", "def stable_marker_fn():\n    pass\n");
+    write_fixture(&root, "mod_churn.py", "def churn_fn_0():\n    pass\n");
+    {
+        let registry = infigraph_languages::bundled_registry().expect("bundled registry");
+        let mut prism = infigraph_core::Infigraph::open(&root, registry).expect("open initial");
+        prism.init().expect("init initial");
+        index_full(&mut prism);
+    }
+
+    // Control: confirm the stable symbol is findable via the exact same
+    // direct-query path, with zero concurrent activity.
+    {
+        let reader = KuzuBackend::open_read_only(&db_path).expect("control open_read_only");
+        let rows = reader.get_symbols_for_search().expect("control query");
+        assert!(
+            rows.iter().any(|r| r[1] == "stable_marker_fn"),
+            "control case (no concurrent writer) should find the indexed symbol: {rows:?}"
+        );
+    }
+
+    // --- Writer thread: opens ONE connection and keeps it alive for the
+    // thread's whole life (matching watch_db's held-open-connection design),
+    // repeatedly overwriting the SAME churn file (keeps corpus size, and so
+    // per-iteration write cost, constant) so many fast iterations fit in a
+    // short window. ---
+    let writer_root = root.clone();
+    let writer_done = std::sync::Arc::new(AtomicBool::new(false));
+    let writer_done_flag = std::sync::Arc::clone(&writer_done);
+    let (ready_tx, ready_rx) = mpsc::channel::<()>();
+    let writer = std::thread::spawn(move || {
+        let registry = infigraph_languages::bundled_registry().expect("bundled registry writer");
+        let mut prism =
+            infigraph_core::Infigraph::open(&writer_root, registry).expect("open writer");
+        prism.init().expect("init writer");
+        let _ = ready_tx.send(());
+        let deadline = std::time::Instant::now() + Duration::from_secs(6);
+        let mut i = 0usize;
+        while std::time::Instant::now() < deadline {
+            i += 1;
+            write_fixture(
+                &writer_root,
+                "mod_churn.py",
+                &format!("def churn_fn_{i}():\n    pass\n"),
+            );
+            index_full(&mut prism);
+        }
+        writer_done_flag.store(true, Ordering::Relaxed);
+        // `prism` (and its underlying KuzuBackend connection) stays alive
+        // until this closure returns -- matching a live watcher.
+    });
+
+    ready_rx
+        .recv_timeout(Duration::from_secs(10))
+        .expect("writer failed to signal ready");
+
+    // --- Reader: fire direct read-only queries in a tight loop WHILE the
+    // writer thread above is actively looping through reindex batches. ---
+    let correct = AtomicUsize::new(0);
+    let clean_errors = AtomicUsize::new(0);
+    let wrong_results: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+    let error_samples: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+
+    let mut attempts = 0usize;
+    while !writer_done.load(Ordering::Relaxed) {
+        attempts += 1;
+        match KuzuBackend::open_read_only(&db_path) {
+            Ok(reader) => match reader.get_symbols_for_search() {
+                Ok(rows) if rows.iter().any(|r| r[1] == "stable_marker_fn") => {
+                    correct.fetch_add(1, Ordering::Relaxed);
+                }
+                Ok(rows) => {
+                    wrong_results
+                        .lock()
+                        .unwrap()
+                        .push(format!("query succeeded but missing stable_marker_fn: {rows:?}"));
+                }
+                Err(e) => {
+                    clean_errors.fetch_add(1, Ordering::Relaxed);
+                    error_samples.lock().unwrap().push(format!("query error: {e}"));
+                }
+            },
+            Err(e) => {
+                clean_errors.fetch_add(1, Ordering::Relaxed);
+                error_samples.lock().unwrap().push(format!("open error: {e}"));
+            }
+        }
+    }
+
+    writer.join().expect("writer thread panicked");
+
+    let correct = correct.load(Ordering::Relaxed);
+    let clean_errors = clean_errors.load(Ordering::Relaxed);
+    let wrong = wrong_results.lock().unwrap();
+
+    println!(
+        "RESULT: {attempts} concurrent read attempts while writer actively reindexed -- \
+         {correct} correct, {clean_errors} clean errors, {} silently wrong",
+        wrong.len()
+    );
+    for sample in error_samples.lock().unwrap().iter().take(3) {
+        println!("  error sample: {sample}");
+    }
+
+    assert!(
+        wrong.is_empty(),
+        "BUG REPRODUCED: {} of {attempts} concurrent read-only queries succeeded (no error) but \
+         returned INCORRECT/INCOMPLETE data (missing 'stable_marker_fn', which is guaranteed \
+         present and never touched by the writer) while a writer was actively reindexing \
+         concurrently. This is the silent-partial-results failure mode -- a lock conflict should \
+         either be transparent (correct data) or fail loudly (a clean error), never silently \
+         wrong. First bad result:\n{}",
+        wrong.len(),
+        wrong.first().cloned().unwrap_or_default()
+    );
+
+    assert!(
+        correct + clean_errors == attempts,
+        "accounting mismatch: correct={correct} clean_errors={clean_errors} attempts={attempts}"
+    );
+}

--- a/crates/infigraph-mcp/tests/concurrent_writer_reader.rs
+++ b/crates/infigraph-mcp/tests/concurrent_writer_reader.rs
@@ -38,7 +38,11 @@ fn concurrent_writer_reader_raw_query_correctness_under_load() {
     let root = project.path().to_path_buf();
     let db_path = root.join(".infigraph").join("graph");
 
-    write_fixture(&root, "mod_stable.py", "def stable_marker_fn():\n    pass\n");
+    write_fixture(
+        &root,
+        "mod_stable.py",
+        "def stable_marker_fn():\n    pass\n",
+    );
     write_fixture(&root, "mod_churn.py", "def churn_fn_0():\n    pass\n");
     {
         let registry = infigraph_languages::bundled_registry().expect("bundled registry");
@@ -109,19 +113,24 @@ fn concurrent_writer_reader_raw_query_correctness_under_load() {
                     correct.fetch_add(1, Ordering::Relaxed);
                 }
                 Ok(rows) => {
-                    wrong_results
-                        .lock()
-                        .unwrap()
-                        .push(format!("query succeeded but missing stable_marker_fn: {rows:?}"));
+                    wrong_results.lock().unwrap().push(format!(
+                        "query succeeded but missing stable_marker_fn: {rows:?}"
+                    ));
                 }
                 Err(e) => {
                     clean_errors.fetch_add(1, Ordering::Relaxed);
-                    error_samples.lock().unwrap().push(format!("query error: {e}"));
+                    error_samples
+                        .lock()
+                        .unwrap()
+                        .push(format!("query error: {e}"));
                 }
             },
             Err(e) => {
                 clean_errors.fetch_add(1, Ordering::Relaxed);
-                error_samples.lock().unwrap().push(format!("open error: {e}"));
+                error_samples
+                    .lock()
+                    .unwrap()
+                    .push(format!("open error: {e}"));
             }
         }
     }


### PR DESCRIPTION
## Summary

Bumps the `lbug` (kuzu-compatible graph DB) dependency from `0.16.0` to `0.19.1` across the three crates that pin it (`infigraph-core`, `infigraph-cli`, `infigraph-docs`), and adds a regression test that documents and guards the concurrency finding this bump resolves.

## Why this was pinned at 0.16.0

A prior attempt to bump to `0.18.3` was paused after finding that a **read-only `Database::new()` racing a live writer holding an open connection** intermittently returned inconsistent results or crashed:

- On `0.16.0` this access pattern fails **cleanly** (a lock-contention-style error — safe).
- On `0.18.3`/`0.19.0` it could **SIGSEGV**, or surface a spurious "duplicated primary key" error even though no such duplicate exists in the committed data.

This was filed against the `lbug` project as [LadybugDB/ladybug#766](https://github.com/LadybugDB/ladybug/issues/766) (full repro included there — the same test added in this PR). It was triaged as a duplicate of tracking issue [#666](https://github.com/LadybugDB/ladybug/issues/666), and the actual fix landed in [LadybugDB/ladybug#615](https://github.com/LadybugDB/ladybug/pull/615) ("Fix read-only open during checkpoint from reading inconsistent state"), merged 2026-07-11 — first released in `0.18.2`.

## Verification

Rather than trust the changelog/issue-tracker resolution alone, this was re-verified empirically:

- `crates/infigraph-mcp/tests/concurrent_writer_reader.rs` (new in this PR): a writer thread holds one long-lived connection open and reindexes in a loop for ~6s; the main thread concurrently opens fresh read-only connections in a tight loop and queries for a symbol guaranteed to exist. Asserts every read is either correct or a clean `Err` — never wrong/missing data, and empirically never crashes.
- Run against `0.19.1`: **0 SIGSEGV, 0 wrong results** across repeated runs (up to several hundred concurrent read attempts against an active writer per run) — matching `0.16.0`'s original safe fail-closed semantics.
- No API breakage `0.16.0` → `0.19.1` — clean build, no call-site changes needed anywhere in the workspace.
- Full workspace build + `cargo test --workspace` pass cleanly on top of current `main` (verified in a fresh worktree off `main`, not just the fork's own branch state).
- `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` clean (pre-existing, unrelated clippy drift on `main` itself was confirmed via a separate bare-`main` check before drawing that conclusion, and is not touched by this PR).

### A false alarm worth mentioning for reviewers

While testing this in a `git worktree` off `main`, `compression_eval::phase2_compression_eval` initially appeared to fail in a way that looked concerningly similar to the original concurrency finding (degenerate/tiny results). Investigation traced it to an unrelated auto-indexing quirk specific to running that test against a small git-worktree diff (it ended up indexing only the files changed by this PR's own two commits, not the full project) — confirmed by directly probing `list_files`/`get_stats` output and diffing against `git log --name-only`. It reproduces identically with or without this dependency bump and is a pre-existing test-environment sensitivity, not a regression from this change. Flagging it here in case it's useful, but it shouldn't block this PR.

## Non-goals

This does not touch any lock/retry logic, error handling, or call sites — it is a pure version bump plus its own regression test.