### PR TITLE
Fixes #73: invalidate the incremental cache on extractor change, not just file change

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -279,10 +279,10 @@ If the Model2Vec model files are not found, the embedder automatically falls bac
 
 ## 8. Incremental Indexing
 
-Every indexed file has its SHA-256 content hash stored in the `Module` node (`content_hash` property). On subsequent `infigraph index` runs:
+Every indexed file has a SHA-256 fingerprint stored in the `Module` node (`content_hash` property). The fingerprint covers both halves of staleness: the file's bytes **and** the language pack that parsed it (its `entities.scm`/`relations.scm` sources, the grammar's structural identity, its custom edge definitions, and `EXTRACTOR_SCHEMA_VERSION`). Upgrading an extractor therefore re-extracts the files that extractor owns without a `--full` reindex, and without disturbing other languages. On subsequent `infigraph index` runs:
 
-1. All files are hashed (in parallel via rayon)
-2. Files whose hash matches the stored hash are skipped entirely — no re-parsing, no graph updates
+1. All files are fingerprinted (in parallel via rayon) via `LanguagePack::content_fingerprint`
+2. Files whose fingerprint matches the stored one are skipped entirely — no re-parsing, no graph updates
 3. Changed and new files are re-parsed and their nodes/edges are deleted and reinserted
 4. The cross-file call resolution pass only re-resolves calls from changed files, but reads the full symbol table from the graph (so cross-file edges from unchanged files are preserved)
 

--- a/crates/infigraph-core/src/extract/mod.rs
+++ b/crates/infigraph-core/src/extract/mod.rs
@@ -4,7 +4,6 @@ pub use entities::extract_entities;
 pub use relations::{extract_relations, extract_relations_with_custom_edges};
 
 use anyhow::Result;
-use sha2::{Digest, Sha256};
 
 use crate::analysis::extract_statements;
 use crate::lang::{LanguagePack, ParserBackend};
@@ -63,11 +62,7 @@ pub fn extract_file(path: &str, source: &[u8], pack: &LanguagePack) -> Result<Fi
     // Generate CALLS edges from Route symbols to their handler functions
     generate_route_handler_edges(path, &symbols, &mut relations);
 
-    let content_hash = {
-        let mut hasher = Sha256::new();
-        hasher.update(source);
-        format!("{:x}", hasher.finalize())
-    };
+    let content_hash = pack.content_fingerprint(source);
 
     Ok(FileExtraction {
         file: path.to_string(),

--- a/crates/infigraph-core/src/lang/mod.rs
+++ b/crates/infigraph-core/src/lang/mod.rs
@@ -4,9 +4,51 @@ pub use registry::LanguageRegistry;
 
 use anyhow::Result;
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 use tree_sitter::{Language, Query};
 
 use crate::model::{Relation, Symbol};
+
+/// Version of the Rust-side extraction logic, mixed into every language pack's
+/// fingerprint and therefore into every `Module.content_hash`.
+///
+/// Bump this when a change to `extract/` alters the graph produced from source
+/// that hasn't itself changed — a symbol-ID scheme fix, a new derived edge, a
+/// different span convention. Doing so re-extracts every file on the next
+/// `infigraph index` instead of leaving existing indexes on the old behavior.
+///
+/// Query-file and grammar changes are detected automatically and need no bump.
+pub const EXTRACTOR_SCHEMA_VERSION: u32 = 1;
+
+/// Combine `parts` into one fingerprint, length-prefixing each so that different
+/// splits can't collide (`"ab" + "c"` must not fingerprint the same as
+/// `"a" + "bc"`).
+///
+/// Public so that out-of-crate extractors can build a fingerprint for
+/// `LanguagePack::with_fingerprint_part` using this same convention.
+pub fn fingerprint_parts(parts: &[&[u8]]) -> String {
+    let mut hasher = Sha256::new();
+    for part in parts {
+        hasher.update((part.len() as u64).to_le_bytes());
+        hasher.update(part);
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+/// Identify a compiled grammar closely enough to detect an upgrade.
+///
+/// tree-sitter exposes no grammar version, so this uses the structural counts it
+/// does expose. `parse_state_count` in particular shifts on essentially any
+/// change to the grammar's rules, which is what we need to catch.
+fn grammar_fingerprint(grammar: &Language) -> String {
+    format!(
+        "{}:{}:{}:{}",
+        grammar.abi_version(),
+        grammar.node_kind_count(),
+        grammar.field_count(),
+        grammar.parse_state_count(),
+    )
+}
 
 /// A custom edge type that a language pack can define beyond the standard
 /// CALLS/IMPORTS/INHERITS model. Custom edges are populated during extraction
@@ -50,6 +92,12 @@ pub struct LanguagePack {
     pub extensions: Vec<String>,
     pub backend: ParserBackend,
     pub custom_edges: Vec<CustomEdgeDef>,
+    /// Digest of everything about this pack that affects what extraction
+    /// produces: the query sources, the grammar, the custom edge definitions,
+    /// and `EXTRACTOR_SCHEMA_VERSION`. Folded into `content_fingerprint` so an
+    /// upgraded extractor invalidates the incremental cache for its own
+    /// language and no other.
+    fingerprint: String,
 }
 
 impl LanguagePack {
@@ -63,6 +111,13 @@ impl LanguagePack {
     ) -> Result<Self> {
         let entity_query = Query::new(&grammar, entity_query_src)?;
         let relation_query = Box::new(Query::new(&grammar, relation_query_src)?);
+        let fingerprint = fingerprint_parts(&[
+            &EXTRACTOR_SCHEMA_VERSION.to_le_bytes(),
+            name.as_bytes(),
+            grammar_fingerprint(&grammar).as_bytes(),
+            entity_query_src.as_bytes(),
+            relation_query_src.as_bytes(),
+        ]);
         Ok(Self {
             name: name.to_string(),
             extensions: extensions.into_iter().map(String::from).collect(),
@@ -73,6 +128,7 @@ impl LanguagePack {
                 inherit_decompose_query: None,
             },
             custom_edges: Vec::new(),
+            fingerprint,
         })
     }
 
@@ -81,6 +137,7 @@ impl LanguagePack {
     /// to their base identifier. Only meaningful for `ParserBackend::TreeSitter` packs;
     /// a no-op on `Custom` backends.
     pub fn with_inherit_decompose(mut self, query_src: &str) -> Result<Self> {
+        let mut applied = false;
         if let ParserBackend::TreeSitter {
             grammar,
             inherit_decompose_query,
@@ -88,6 +145,14 @@ impl LanguagePack {
         } = &mut self.backend
         {
             *inherit_decompose_query = Some(Box::new(Query::new(grammar, query_src)?));
+            applied = true;
+        }
+        if applied {
+            self.fingerprint = fingerprint_parts(&[
+                self.fingerprint.as_bytes(),
+                b"inherit_decompose",
+                query_src.as_bytes(),
+            ]);
         }
         Ok(self)
     }
@@ -108,22 +173,70 @@ impl LanguagePack {
             entity_query_src,
             relation_query_src,
         )?;
+        let fingerprint = {
+            let mut parts: Vec<&[u8]> = vec![pack.fingerprint.as_bytes(), b"custom_edges"];
+            for edge in &custom_edges {
+                parts.push(edge.name.as_bytes());
+                parts.push(edge.capture.as_bytes());
+            }
+            fingerprint_parts(&parts)
+        };
+        pack.fingerprint = fingerprint;
         pack.custom_edges = custom_edges;
         Ok(pack)
     }
 
     /// Create a language pack with a custom extraction backend.
+    ///
+    /// The fingerprint can only cover this crate's schema version and the pack's
+    /// identity — a runtime-loaded extractor's own behavior is opaque from here,
+    /// so upgrading a grammar plugin in place does not by itself invalidate the
+    /// cache for its files. Use `with_fingerprint_part` to mix in whatever the
+    /// caller knows about the extractor's version.
     pub fn new_custom(
         name: &str,
         extensions: Vec<String>,
         extractor: Box<dyn CustomExtractor>,
     ) -> Self {
+        let fingerprint = fingerprint_parts(&[
+            &EXTRACTOR_SCHEMA_VERSION.to_le_bytes(),
+            b"custom_backend",
+            name.as_bytes(),
+        ]);
         Self {
             name: name.to_string(),
             extensions,
             backend: ParserBackend::Custom(extractor),
             custom_edges: Vec::new(),
+            fingerprint,
         }
+    }
+
+    /// Mix additional caller-known versioning into this pack's fingerprint —
+    /// intended for custom backends whose extraction behavior this crate can't
+    /// inspect (see `new_custom`). Changing the part re-extracts only this
+    /// pack's files.
+    pub fn with_fingerprint_part(mut self, part: &str) -> Self {
+        self.fingerprint = fingerprint_parts(&[self.fingerprint.as_bytes(), part.as_bytes()]);
+        self
+    }
+
+    /// Opaque digest of this pack's extraction behavior. Exposed for diagnostics;
+    /// callers deciding whether a file needs re-extraction want
+    /// `content_fingerprint` instead.
+    pub fn fingerprint(&self) -> &str {
+        &self.fingerprint
+    }
+
+    /// The value stored as `Module.content_hash` and compared against on the
+    /// next run to decide whether `source` can be skipped.
+    ///
+    /// It covers both halves of staleness: the file's contents *and* the
+    /// extraction behavior that produced its rows. Every producer of a
+    /// `content_hash` and every consumer deciding to skip must go through this
+    /// one function, or unchanged files re-extract on every run.
+    pub fn content_fingerprint(&self, source: &[u8]) -> String {
+        fingerprint_parts(&[source, self.fingerprint.as_bytes()])
     }
 }
 

--- a/crates/infigraph-core/src/lib.rs
+++ b/crates/infigraph-core/src/lib.rs
@@ -39,7 +39,6 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use rayon::prelude::*;
-use sha2::{Digest, Sha256};
 
 use graph::GraphStore;
 use lang::LanguageRegistry;
@@ -306,11 +305,11 @@ impl Infigraph {
                     None => raw_rel.clone(),
                 };
                 let source = std::fs::read(path).ok()?;
-                let hash = {
-                    let mut h = Sha256::new();
-                    h.update(&source);
-                    format!("{:x}", h.finalize())
-                };
+                // Resolve the pack before hashing: the skip decision has to use the
+                // same fingerprint `extract_file` will store, and that covers the
+                // pack's extraction behavior as well as the file's bytes.
+                let pack = self.registry.for_file_with_content(&rel_path, &source)?;
+                let hash = pack.content_fingerprint(&source);
                 let n = done.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
                 let pct = n * 100 / total;
                 let prev_pct = (n - 1) * 100 / total;
@@ -320,7 +319,6 @@ impl Infigraph {
                 if existing_hashes.get(&rel_path).map(|s| s.as_str()) == Some(hash.as_str()) {
                     return None;
                 }
-                let pack = self.registry.for_file_with_content(&rel_path, &source)?;
                 extract::extract_file(&rel_path, &source, pack).ok()
             })
             .collect();

--- a/crates/infigraph-core/tests/extract_pipeline.rs
+++ b/crates/infigraph-core/tests/extract_pipeline.rs
@@ -1,5 +1,5 @@
 use infigraph_core::extract::extract_file;
-use infigraph_core::lang::LanguagePack;
+use infigraph_core::lang::{CustomEdgeDef, LanguagePack};
 use infigraph_core::model::{RelationKind, SymbolKind};
 
 const PYTHON_ENTITIES: &str = r#"
@@ -280,6 +280,140 @@ fn test_extract_content_hash_changes() {
     let ext1 = extract_file("f.py", b"def a(): pass", &pack).unwrap();
     let ext2 = extract_file("f.py", b"def b(): pass", &pack).unwrap();
     assert_ne!(ext1.content_hash, ext2.content_hash);
+}
+
+// ---------- extractor-aware cache invalidation ----------
+
+/// The incremental skip gate in `Infigraph::index` hashes a file before it has
+/// an extraction to compare against, so it calls `content_fingerprint` directly.
+/// If that formula ever drifts from what `extract_file` stores, no file is ever
+/// skipped again and every index becomes a full reindex.
+#[test]
+fn test_content_fingerprint_matches_stored_content_hash() {
+    let src = b"def foo():\n    pass\n";
+    let pack = python_pack();
+    let ext = extract_file("foo.py", src, &pack).unwrap();
+    assert_eq!(pack.content_fingerprint(src), ext.content_hash);
+}
+
+/// A query-file fix must invalidate the cache for files it affects, otherwise
+/// users who upgrade keep the graph the old, buggy extractor produced.
+#[test]
+fn test_content_hash_changes_when_entity_query_changes() {
+    let src = b"def foo():\n    pass\n";
+
+    let before = python_pack();
+    let after = LanguagePack::new(
+        "python",
+        vec![".py"],
+        tree_sitter_python::LANGUAGE.into(),
+        // Stand-in for an extractor fix: one extra pattern in entities.scm.
+        &format!("{PYTHON_ENTITIES}\n(lambda) @func.def\n"),
+        PYTHON_RELATIONS,
+    )
+    .unwrap();
+
+    assert_ne!(
+        before.content_fingerprint(src),
+        after.content_fingerprint(src),
+        "an entity-query change must produce a different fingerprint for identical source"
+    );
+}
+
+#[test]
+fn test_content_hash_changes_when_relation_query_changes() {
+    let src = b"def foo():\n    bar()\n";
+
+    let before = python_pack();
+    let after = LanguagePack::new(
+        "python",
+        vec![".py"],
+        tree_sitter_python::LANGUAGE.into(),
+        PYTHON_ENTITIES,
+        &format!(
+            "{PYTHON_RELATIONS}\n(await (call function: (identifier) @call.name)) @call.site\n"
+        ),
+    )
+    .unwrap();
+
+    assert_ne!(
+        before.content_fingerprint(src),
+        after.content_fingerprint(src)
+    );
+}
+
+/// The fingerprint is derived per pack rather than from a global index version,
+/// so an extractor fix for one language leaves other languages cached. (Mixing
+/// in the Infigraph crate version instead would make every release a full
+/// reindex.) `test_extractor_change_reindexes_unedited_files` in `index_perf.rs`
+/// covers the same property end-to-end through `index()`.
+#[test]
+fn test_pack_fingerprint_is_scoped_to_its_own_inputs() {
+    let py = python_pack();
+    let py_upgraded = LanguagePack::new(
+        "python",
+        vec![".py"],
+        tree_sitter_python::LANGUAGE.into(),
+        &format!("{PYTHON_ENTITIES}\n(lambda) @func.def\n"),
+        PYTHON_RELATIONS,
+    )
+    .unwrap();
+
+    // Same grammar and same queries, different pack — the fingerprint must still
+    // distinguish them, so packs can be invalidated independently.
+    let other = LanguagePack::new(
+        "python-other",
+        vec![".pyi"],
+        tree_sitter_python::LANGUAGE.into(),
+        PYTHON_ENTITIES,
+        PYTHON_RELATIONS,
+    )
+    .unwrap();
+
+    assert_ne!(
+        py.fingerprint(),
+        py_upgraded.fingerprint(),
+        "the edited pack must be invalidated"
+    );
+    assert_ne!(
+        py.fingerprint(),
+        other.fingerprint(),
+        "distinct packs must not share a fingerprint"
+    );
+}
+
+/// Fingerprints are compared across processes and across runs, so they must not
+/// depend on anything address- or run-specific.
+#[test]
+fn test_pack_fingerprint_is_stable_across_rebuilds() {
+    assert_eq!(python_pack().fingerprint(), python_pack().fingerprint());
+}
+
+#[test]
+fn test_inherit_decompose_query_affects_fingerprint() {
+    let plain = python_pack();
+    let decomposed = python_pack()
+        .with_inherit_decompose("(subscript value: (identifier) @base)")
+        .unwrap();
+    assert_ne!(plain.fingerprint(), decomposed.fingerprint());
+}
+
+#[test]
+fn test_custom_edges_affect_fingerprint() {
+    let plain = python_pack();
+    let with_edges = LanguagePack::new_with_custom_edges(
+        "python",
+        vec![".py"],
+        tree_sitter_python::LANGUAGE.into(),
+        PYTHON_ENTITIES,
+        PYTHON_RELATIONS,
+        vec![CustomEdgeDef {
+            name: "PUBLISHES".to_string(),
+            capture: "publish".to_string(),
+        }],
+    )
+    .unwrap();
+    assert_ne!(plain.fingerprint(), with_edges.fingerprint());
 }
 
 #[test]

--- a/crates/infigraph-core/tests/index_perf.rs
+++ b/crates/infigraph-core/tests/index_perf.rs
@@ -350,6 +350,60 @@ fn test_incremental_index_only_changed() {
     );
 }
 
+/// Upgrading an extractor must reach existing indexes on its own.
+///
+/// Before `content_hash` covered the language pack, a query fix never re-ran on
+/// unedited files: their content hash still matched, so they were skipped
+/// indefinitely and the graph kept whatever the old, buggy extractor produced —
+/// silently, unless the user knew to run `index --full`.
+#[test]
+fn test_extractor_change_reindexes_unedited_files() {
+    let (dir, ig) = make_project(5);
+    assert_eq!(ig.index().unwrap().indexed_files, 5, "first index is full");
+    // Kuzu is single-writer: release the graph before reopening it.
+    drop(ig);
+
+    let reindex_with = |pack: LanguagePack| {
+        let mut reg = LanguageRegistry::new();
+        reg.register(pack);
+        let mut ig = Infigraph::open(dir.path(), reg).unwrap();
+        ig.init().unwrap();
+        let indexed = ig.index().unwrap().indexed_files;
+        drop(ig);
+        indexed
+    };
+
+    assert_eq!(
+        reindex_with(python_pack()),
+        0,
+        "same files and same extractor must still skip everything"
+    );
+
+    // Stand-in for shipping an extractor fix: one more pattern in entities.scm.
+    let upgraded = || {
+        LanguagePack::new(
+            "python",
+            vec![".py"],
+            tree_sitter_python::LANGUAGE.into(),
+            &format!("{PYTHON_ENTITIES}\n(lambda) @func.def\n"),
+            PYTHON_RELATIONS,
+        )
+        .unwrap()
+    };
+
+    assert_eq!(
+        reindex_with(upgraded()),
+        5,
+        "an upgraded extractor must re-extract its files without --full"
+    );
+    assert_eq!(
+        reindex_with(upgraded()),
+        0,
+        "re-extraction must settle: the upgraded extractor is now the stored \
+         fingerprint, so a further run skips again rather than reindexing forever"
+    );
+}
+
 #[test]
 fn test_large_project_index() {
     let (_dir, ig) = make_project(200);

--- a/crates/infigraph-grammar-plugin/src/lib.rs
+++ b/crates/infigraph-grammar-plugin/src/lib.rs
@@ -3,7 +3,8 @@ mod plugin;
 
 pub use driver::GrammarDriver;
 pub use plugin::{
-    discover_plugins, GrammarPlugin, GrammarPluginConfig, ProjectConfig, ProjectPreprocessorConfig,
+    discover_plugins, plugin_fingerprint, GrammarPlugin, GrammarPluginConfig, ProjectConfig,
+    ProjectPreprocessorConfig,
 };
 
 use std::path::Path;
@@ -125,6 +126,8 @@ pub fn register_grammar_plugins(
     for (config, dir) in all_plugins {
         let name = config.language.name.clone();
         let extensions = config.language.extensions.clone();
+        // Computed before `config`/`dir` move into the plugin.
+        let fingerprint = plugin_fingerprint(&config, &dir);
 
         let plugin = GrammarPlugin::new(config, dir, Arc::clone(&driver), project_pp.clone());
 
@@ -136,7 +139,8 @@ pub fn register_grammar_plugins(
             continue;
         }
 
-        let pack = LanguagePack::new_custom(&name, extensions, Box::new(plugin));
+        let pack = LanguagePack::new_custom(&name, extensions, Box::new(plugin))
+            .with_fingerprint_part(&fingerprint);
         registry.register(pack);
     }
 

--- a/crates/infigraph-grammar-plugin/src/plugin.rs
+++ b/crates/infigraph-grammar-plugin/src/plugin.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
-use infigraph_core::lang::CustomExtractor;
+use infigraph_core::lang::{fingerprint_parts, CustomExtractor};
 use infigraph_core::model::{Relation, RelationKind, Span, Symbol, SymbolKind};
 
 use crate::driver::GrammarDriver;
@@ -243,6 +243,43 @@ pub fn discover_plugins(plugins_dir: &Path) -> Result<Vec<(GrammarPluginConfig, 
 /// source file is resolved to an absolute path next to `plugin.toml` (the
 /// driver compiles it on load); anything else (e.g. `"GenericExtractor"`)
 /// passes through unchanged.
+/// Digest of everything in a plugin directory that determines what the plugin
+/// extracts: its `plugin.toml` (entry rule, preprocessor and lexing flags), both
+/// ANTLR grammars, and the extractor source when it ships with the plugin. A
+/// built-in extractor lives in the driver jar instead, so only its name is
+/// covered — replacing the jar is not detected here.
+///
+/// Mixed into the language pack's fingerprint so that swapping a plugin's
+/// grammar or extractor re-indexes that language's files, the same way editing a
+/// tree-sitter query does. Without it, a plugin upgrade would leave existing
+/// indexes on the old extractor's output indefinitely.
+///
+/// An unreadable input contributes its path rather than its bytes, so a plugin
+/// we can't hash stays cacheable instead of re-extracting on every run.
+pub fn plugin_fingerprint(config: &GrammarPluginConfig, plugin_dir: &Path) -> String {
+    let lang = &config.language;
+    let mut inputs = vec![
+        plugin_dir.join("plugin.toml"),
+        plugin_dir.join(&lang.lexer),
+        plugin_dir.join(&lang.parser),
+    ];
+    if lang.extractor.ends_with(".java") {
+        inputs.push(plugin_dir.join(&lang.extractor));
+    }
+
+    let contents: Vec<Vec<u8>> = inputs
+        .iter()
+        .map(|path| {
+            std::fs::read(path).unwrap_or_else(|_| path.to_string_lossy().as_bytes().to_vec())
+        })
+        .collect();
+
+    let mut parts: Vec<&[u8]> = Vec::with_capacity(contents.len() + 1);
+    parts.push(lang.extractor.as_bytes());
+    parts.extend(contents.iter().map(|c| c.as_slice()));
+    fingerprint_parts(&parts)
+}
+
 fn resolve_extractor(plugin_dir: &Path, extractor: &str) -> Result<String> {
     if extractor.ends_with(".java") {
         let joined = plugin_dir.join(extractor);
@@ -292,6 +329,96 @@ fn parse_relation_kind(s: &str) -> RelationKind {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Write a minimal plugin directory and return it with its parsed config.
+    fn write_plugin(dir: &Path, lexer_src: &str, extractor: &str) -> GrammarPluginConfig {
+        let toml_src = format!(
+            "[language]\nname = \"demo\"\nextensions = [\".demo\"]\n\
+             entry_rule = \"program\"\nlexer = \"DemoLexer.g4\"\n\
+             parser = \"DemoParser.g4\"\nextractor = \"{extractor}\"\n"
+        );
+        std::fs::write(dir.join("plugin.toml"), &toml_src).unwrap();
+        std::fs::write(dir.join("DemoLexer.g4"), lexer_src).unwrap();
+        std::fs::write(dir.join("DemoParser.g4"), "parser grammar DemoParser;").unwrap();
+        std::fs::write(dir.join("Extractor.java"), "class Extractor {}").unwrap();
+        toml::from_str(&toml_src).unwrap()
+    }
+
+    #[test]
+    fn test_plugin_fingerprint_is_stable_for_unchanged_plugin() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let config = write_plugin(dir.path(), "lexer grammar DemoLexer;", "Extractor.java");
+        assert_eq!(
+            plugin_fingerprint(&config, dir.path()),
+            plugin_fingerprint(&config, dir.path()),
+            "an untouched plugin must keep its fingerprint, so its files stay cached"
+        );
+    }
+
+    /// Replacing a plugin's grammar has to invalidate its files, the same way
+    /// editing a tree-sitter query does — otherwise the upgrade never reaches an
+    /// existing index.
+    #[test]
+    fn test_plugin_fingerprint_changes_when_grammar_changes() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let config = write_plugin(dir.path(), "lexer grammar DemoLexer;", "Extractor.java");
+        let before = plugin_fingerprint(&config, dir.path());
+
+        std::fs::write(
+            dir.path().join("DemoLexer.g4"),
+            "lexer grammar DemoLexer;\nID : [a-z]+ ;",
+        )
+        .unwrap();
+
+        assert_ne!(before, plugin_fingerprint(&config, dir.path()));
+    }
+
+    #[test]
+    fn test_plugin_fingerprint_changes_when_extractor_source_changes() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let config = write_plugin(dir.path(), "lexer grammar DemoLexer;", "Extractor.java");
+        let before = plugin_fingerprint(&config, dir.path());
+
+        std::fs::write(
+            dir.path().join("Extractor.java"),
+            "class Extractor { void more() {} }",
+        )
+        .unwrap();
+
+        assert_ne!(before, plugin_fingerprint(&config, dir.path()));
+    }
+
+    /// A built-in extractor's code lives in the driver jar, so switching which
+    /// built-in a plugin uses is the only part of it we can detect.
+    #[test]
+    fn test_plugin_fingerprint_changes_when_builtin_extractor_switched() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let with_builtin = write_plugin(dir.path(), "lexer grammar DemoLexer;", "BuiltinA");
+        let a = plugin_fingerprint(&with_builtin, dir.path());
+
+        let with_other = write_plugin(dir.path(), "lexer grammar DemoLexer;", "BuiltinB");
+        assert_ne!(a, plugin_fingerprint(&with_other, dir.path()));
+    }
+
+    /// A plugin whose files can't be read must stay cacheable rather than
+    /// producing a fresh fingerprint (and a full re-extraction) on every run.
+    #[test]
+    fn test_plugin_fingerprint_stable_when_files_missing() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let config = write_plugin(dir.path(), "lexer grammar DemoLexer;", "Extractor.java");
+        for name in [
+            "plugin.toml",
+            "DemoLexer.g4",
+            "DemoParser.g4",
+            "Extractor.java",
+        ] {
+            std::fs::remove_file(dir.path().join(name)).unwrap();
+        }
+        assert_eq!(
+            plugin_fingerprint(&config, dir.path()),
+            plugin_fingerprint(&config, dir.path())
+        );
+    }
 
     #[test]
     fn test_parse_symbol_kind_all_variants() {

--- a/docs/CODE-PARSING.md
+++ b/docs/CODE-PARSING.md
@@ -182,7 +182,7 @@ The core parsing function for a single file:
 4. Run `extract_relations` — executes `relations.scm` query against the AST
 5. Run `extract_statements_for_symbols` — extracts statement-level detail
 6. Generate route → handler CALLS edges via `generate_route_handler_edges`
-7. Compute SHA-256 `content_hash` of the file
+7. Compute the SHA-256 `content_hash` fingerprint over the file bytes plus the language pack's extractor fingerprint (`LanguagePack::content_fingerprint`)
 
 ### entities.scm — Symbol extraction
 
@@ -465,7 +465,7 @@ Old data for changed files is deleted via `DETACH DELETE` before re-inserting.
 
 ### File hash storage
 
-Content hashes are stored on `Module` nodes via the `content_hash` column. Retrieved by `get_file_hashes()` (`graph/cozo_store.rs:1405-1412`, `graph/store.rs:163-175`) for incremental indexing.
+Content fingerprints are stored on `Module` nodes via the `content_hash` column. Retrieved by `get_file_hashes()` (`graph/cozo_store.rs:1405-1412`, `graph/store.rs:163-175`) for incremental indexing.
 
 ---
 
@@ -474,10 +474,28 @@ Content hashes are stored on `Module` nodes via the `content_hash` column. Retri
 ### How it works
 
 1. Walk the directory tree, collect all source files
-2. Hash each file with SHA-256
-3. Load previously stored hashes via `get_file_hashes()`
-4. **Skip** files whose hash hasn't changed
+2. Fingerprint each file with `LanguagePack::content_fingerprint` — SHA-256 over the file's bytes **and** the pack's extractor fingerprint
+3. Load previously stored fingerprints via `get_file_hashes()`
+4. **Skip** files whose fingerprint hasn't changed
 5. Re-parse and re-extract only changed/new files
+
+### What invalidates a file's fingerprint
+
+Because the fingerprint folds in the language pack, a file becomes stale either when the user edits it or when Infigraph's own extraction for that language changes:
+
+| Change | Detected | How |
+|--------|----------|-----|
+| File edited | exact | file bytes |
+| `entities.scm` / `relations.scm` edited | exact | query sources hashed into the pack fingerprint |
+| Custom edge definitions changed | exact | edge name/capture pairs |
+| Grammar crate upgraded | heuristic | ABI version plus node-kind/field/parse-state counts — tree-sitter exposes no grammar version, so an upgrade that leaves all four counts unchanged is missed |
+| Runtime grammar-plugin (ANTLR) grammar, extractor source, or `plugin.toml` changed | exact | `plugin_fingerprint` hashes the plugin directory's inputs into the pack via `LanguagePack::with_fingerprint_part` |
+| Rust-side extraction logic changed (symbol-ID scheme, new derived edge, span convention) | **manual** | bump `EXTRACTOR_SCHEMA_VERSION` in `lang/mod.rs` |
+| Grammar-plugin built-in extractor changed inside the driver jar | **not detected** | the jar's contents are opaque; only the extractor's name is covered |
+
+The fingerprint is deliberately *per pack*, not global: a Java query fix re-extracts Java files and leaves Python and TypeScript cached. Mixing in the Infigraph crate version instead would make every release a full reindex.
+
+Two call sites produce a `content_hash` — the skip gate in `Infigraph::index_via_backend` and `extract_file` — and they must use the same formula, hence the single `content_fingerprint` function. If they ever diverge, nothing is skipped and every index silently becomes a full reindex; `test_incremental_index_skips_unchanged` (`tests/index_perf.rs`, `#[ignore]`d, run with `--ignored`) is the guard.
 6. Delete old symbols/edges for changed files via `DETACH DELETE`
 7. Insert new symbols/edges via Parquet COPY
 8. Delete symbols for files that no longer exist on disk (stale pruning)


### PR DESCRIPTION
## Summary

Fixes #73 .

`Module.content_hash` only covers the file's bytes, so `index()` skips any file whose contents haven't changed — even when the extractor that parsed it has. Extractor fixes therefore never reach an existing index. 3.2.16's Java `method_reference` and C++ namespace-scoping fixes both silently missed anyone who didn't happen to run `index --full`.

`LanguagePack` now carries a fingerprint built from its `entities.scm` / `relations.scm` sources, the grammar's identity, its custom edge definitions, and a new `EXTRACTOR_SCHEMA_VERSION` for Rust-side changes. `content_fingerprint` folds that into the per-file hash.

It's scoped per pack, so a Java query fix re-extracts Java files and leaves Python and TypeScript cached. Bumping a single global version would also work, but would mean a full reindex on every release.

Two places computed the file hash independently — the skip gate in `index_via_backend` and `extract_file`. Both now go through `content_fingerprint`. If those ever drift apart nothing gets skipped and every index quietly becomes a full one, so there's a test pinning it.

Grammar plugins get the same treatment via `plugin_fingerprint`, over the plugin's `plugin.toml`, its `.g4` grammars and its extractor source.

No schema migration — `content_hash` is already an opaque string in every backend.

One caveat: tree-sitter exposes no grammar version, so grammar identity is inferred from `abi_version` plus the node-kind / field / parse-state counts. An upgrade leaving all four unchanged would be missed. Rust-side extractor changes still need a manual `EXTRACTOR_SCHEMA_VERSION` bump. Both are documented in `docs/CODE-PARSING.md`.

## Test plan

- [x] `cargo test --all` — 1263 passed, 0 failed (13 new)
- [x] `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo check --features remote -p infigraph-core -p infigraph-cli -p infigraph-mcp` — clean (CI builds default features only; the release workflow uses `--features remote`)
- [x] `cargo test -p infigraph-core --test index_perf -- --ignored` — `test_incremental_index_skips_unchanged` still skips everything, confirming the skip gate and the stored hash agree

The main new one is `test_extractor_change_reindexes_unedited_files`: index a project, reopen with the same pack (nothing re-indexed), reopen with a changed pack (all re-indexed), reopen again with the changed pack (nothing). That last step is the one that matters — it proves this doesn't turn into a permanent reindex loop.

## Notes

Adding a private field to `LanguagePack` is technically breaking for struct-literal construction downstream, so this probably wants a minor bump rather than a patch.